### PR TITLE
eff-cats => eff name migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eff
 
-[![Build Status](https://travis-ci.org/atnos-org/eff-cats.png?branch=master)](https://travis-ci.org/atnos-org/eff-cats)
+[![Build Status](https://travis-ci.org/atnos-org/eff.png?branch=master)](https://travis-ci.org/atnos-org/eff)
 [![Join the chat at https://gitter.im/atnos-org/eff](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/atnos-org/eff?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Extensible effects are an alternative to monad transformers for computing with effects in a functional way.
@@ -9,20 +9,20 @@ Oleg Kiselyov in [Freer monads, more extensible effects](http://okmij.org/ftp/Ha
 
 You can learn more in the User Guide:
 
- - [your first effects](http://atnos-org.github.io/eff-cats/org.atnos.site.Introduction.html)
- - [included effects: `Reader`, `Writer`, `Eval`, `State`,...](http://atnos-org.github.io/eff-cats/org.atnos.site.OutOfTheBox.html)
- - [create your own effects](http://atnos-org.github.io/eff-cats/org.atnos.site.CreateEffects.html)
- - [use Member implicits](http://atnos-org.github.io/eff-cats/org.atnos.site.MemberImplicits.html)
- - [working with different effect stacks](http://atnos-org.github.io/eff-cats/org.atnos.site.TransformStack.html)
- - [a tutorial similar to the cats' tutorial for Free monads](http://atnos-org.github.io/eff-cats/org.atnos.site.Tutorial.html)
+ - [your first effects](http://atnos-org.github.io/eff/org.atnos.site.Introduction.html)
+ - [included effects: `Reader`, `Writer`, `Eval`, `State`,...](http://atnos-org.github.io/eff/org.atnos.site.OutOfTheBox.html)
+ - [create your own effects](http://atnos-org.github.io/eff/org.atnos.site.CreateEffects.html)
+ - [use Member implicits](http://atnos-org.github.io/eff/org.atnos.site.MemberImplicits.html)
+ - [working with different effect stacks](http://atnos-org.github.io/eff/org.atnos.site.TransformStack.html)
+ - [a tutorial similar to the cats' tutorial for Free monads](http://atnos-org.github.io/eff/org.atnos.site.Tutorial.html)
 
 You can also check out [this presentation](http://bit.ly/eff_flatmap_2016) at flatMap Oslo 2016 ([slides](http://www.slideshare.net/etorreborre/the-eff-monad-one-monad-to-rule-them-all)).
 
 ## Installation
 
-You add `eff-cats` as an sbt dependency:
+You add `eff` as an sbt dependency:
 ```scala
-libraryDependencies += "org.atnos" %% "eff-cats" % "2.0.0-RC18"
+libraryDependencies += "org.atnos" %% "eff" % "2.0.0"
 
 // to write types like Reader[String, ?]
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.0")
@@ -33,7 +33,7 @@ addCompilerPlugin("com.milessabin" % "si2712fix-plugin_2.11.8" % "1.2.0")
 
 # Contributing
 
-[eff-cats](https://github.com/atnos-org/eff-cats/) is a [Typelevel](http://typelevel.org) project. This means we embrace pure, typeful, functional programming,
+[eff](https://github.com/atnos-org/eff/) is a [Typelevel](http://typelevel.org) project. This means we embrace pure, typeful, functional programming,
 and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Typelevel Code of Conduct](http://typelevel.org/conduct.html).
 
 Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about the code. Pull requests are also gladly accepted.


### PR DESCRIPTION
According to documentation and artifacts published yesterday (27.11.2016) it's no longer `eff-cats` project but `eff` project.
Renaming makes this page unusable because of broken URLs and artifact names/versions. I fixed that as much as possible to a working state as I'm using this page sometimes.
Feel free to reject the PR as I was just trying to make this page usable again for myself.