### PR TITLE
Fix Arrs.mapLast for empty case, remove unapplySeq calls

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/ArrsSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ArrsSpec.scala
@@ -1,0 +1,22 @@
+package org.atnos.eff
+
+import cats._
+import cats.instances.all._
+import org.atnos.eff.syntax.all._
+import org.scalacheck.Arbitrary._
+import org.scalacheck._
+import org.specs2.{ScalaCheck, Specification}
+
+class ArrsSpec extends Specification with ScalaCheck { def is = s2"""
+
+ A function can run at the end of a Kleisli arrow into the Eff monad $mapLast
+
+  """
+
+  def mapLast = prop { xs: List[Int] =>
+    type R = Fx.fx1[Eval]
+    val plusOne = Arrs.unit[R, Int].mapLast(_.map(_ + 1))
+    xs.traverseA(plusOne).detach.value ==== xs.map(_ + 1)
+  }.setGen(Gen.listOf(Gen.oneOf(1, 2, 3)))
+
+  }


### PR DESCRIPTION
`Arrs.mapLast` doesn't actually apply the function it's passed if the `Arrs` is empty. This fixes that, removes a couple of `unapplySeq` calls in `go` in favor of explicit `isEmpty` and pulls the `f(v)` call out of the branch. As well, replaces varargs `Vector(A*)` calls to avoid intermediate collections and replaces a call to `EffMonad[R].pure[A]` with `Eff.pure[R, A]` to make IntelliJ happy for now; it otherwise complains as it does not recognize kind projector in cross-projects (because it doesn't really support them). Let me know which changes are welcome. 

I also have some benchmarks pending for data structures for free monads if you are interested (especially implemented with reflection without remorse) at edmundnoble/scabsbench, which may be the basis for further PRs.