### PR TITLE
remind readers to rename the smart constructor 'get'; name conflict i…

### DIFF
--- a/jvm/src/test/scala/org/atnos/site/snippets/tutorial/AdtInterpreterSafeSnippet.scala
+++ b/jvm/src/test/scala/org/atnos/site/snippets/tutorial/AdtInterpreterSafeSnippet.scala
@@ -33,7 +33,10 @@ type _stateMap[R]     = State[Map[String, Any], ?] |= R
  * translating one effect of the stack to other effects in the same stack
  *
  *
- * NOTE: It is really important for type inference that the effects for U are listed after those for R!
+ * NOTE:
+ * - It is really important for type inference that the effects for U are listed after those for R!
+ * - There's a name conflict in the `State Monad` in the pattern match for `Get(key)`
+ *   ;hence, remember to rename your smart constructor defined earlier to something else.
  *
  * Implicit member definitions will NOT be found with the following definition:
  *


### PR DESCRIPTION
…n the State monad. This name conflict is immediately evident when the reader copies-pastes (like i did) of the earlier tutorial on the impure interpreter; best to rename the smart constructor