### PR TITLE
allow to catch only specific exceptions

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/SafeSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/SafeSpec.scala
@@ -1,13 +1,13 @@
 package org.atnos.eff
 
-import cats._
-import data._
+import cats.Eval
 import cats.implicits._
 import org.atnos.eff.all._
 import org.atnos.eff.syntax.all._
 import org.specs2._
 import org.specs2.matcher.{Matcher, ThrownExpectations}
 import org.scalacheck.Gen
+
 import scala.collection.mutable.ListBuffer
 
 class SafeSpec extends Specification with ScalaCheck with ThrownExpectations { def is = s2"""
@@ -31,22 +31,22 @@ class SafeSpec extends Specification with ScalaCheck with ThrownExpectations { d
 
   An exception can simply be ignored $ignoreException1
 
+  Only particular exceptions can be caught and recovered $whenThrowable1
+
+  Safe effect can be mixed with other effects $mixedWithOtherEffects1
+
 """
 
-  type S = Fx.fx2[Safe, Option]
+  type S = Fx.fx1[Safe]
 
   def safe1 = prop { n: Int =>
-    protect[S, Int](action(n)).runSafe.runOption.run ====
-      (if (isEven(n)) Option((Right(n), List()))
-       else           Option((Left(boom), List())))
+    protect[S, Int](action(n)).runSafe.run ====
+      Either.cond(isEven(n), n, boom) -> List()
   }
 
   def attempt1 = prop { n: Int =>
-    protect[S, Int](action(n)).attempt.runSafe.runOption.run ====
-      Option(
-        (Right(if (isEven(n)) Right(n) else Left(boom)),
-         List())
-      )
+    protect[S, Int](action(n)).attempt.runSafe.run ====
+      (Right(Either.cond(isEven(n), n, boom)) -> List())
   }
 
   def finalize1 = prop { (n1: Int, n2: Int, n3: Int, n4: Int) =>
@@ -59,10 +59,10 @@ class SafeSpec extends Specification with ScalaCheck with ThrownExpectations { d
         b <- protect[S, Int](action(n2)) `finally` protect(unitAction { messages.append("finalizer2"); n4 })
       } yield a + b
 
-    val result = program.runSafe.runOption.run
+    val result = program.runSafe.run
 
     result match {
-      case Some((Right(r), ls)) =>
+      case (Right(r), ls) =>
         n1 must beEven
         n2 must beEven
         r ==== (n1 + n2)
@@ -74,7 +74,7 @@ class SafeSpec extends Specification with ScalaCheck with ThrownExpectations { d
 
         messages.toList ==== List("finalizer1", "finalizer2")
 
-      case Some((Left(t), ls)) =>
+      case (Left(t), ls) =>
         (n1 must beOdd) or (n2 must beOdd)
 
         if (isEven(n1)) {
@@ -94,7 +94,7 @@ class SafeSpec extends Specification with ScalaCheck with ThrownExpectations { d
           messages.toList ==== List("finalizer1")
         }
 
-      case None => ok
+      case _ => ok
     }
 
   }.setGens(genInt, genInt, genInt, genInt).noShrink
@@ -105,35 +105,81 @@ class SafeSpec extends Specification with ScalaCheck with ThrownExpectations { d
     val program =
       List(0, 2, 4).traverse(n => protect[S, Int](action(n))).void `finally` protect[S, Unit](messages.append("out"))
 
-    program.runSafe.runOption.run
-    messages.toList must haveSize(1)
+    program.runSafe.run
+    messages.toList ==== List("out")
   }
 
   def catchThrowable1 = prop { n: Int =>
     val program = protect[S, Int](action(n)).catchThrowable(identity, _ => pure(1))
 
-    program.runSafe.runOption.run ==== Option((Right(if (isEven(n)) n else 1), List()))
+    program.runSafe.run ==== (Right(if (isEven(n)) n else 1) -> List())
   }.setGen(genInt)
 
   def catchThrowable2 = prop { n: Int =>
     val program = (protect[S, Int](action(n)) `finally` protect[S, Unit](throw finalBoom)).catchThrowable(identity, _ => pure(1))
 
-    program.runSafe.runOption.run ==== Option((Right(if (isEven(n)) n else 1), List(finalBoom)))
+    program.runSafe.run ==== (Right(if (isEven(n)) n else 1) -> List(finalBoom))
   }.setGen(genInt)
 
   def catchThrowable3 = prop { n: Int =>
     val program = protect[S, Int](action(n)).catchThrowable(identity, _ => pure(1)) `finally` protect[S, Unit](throw finalBoom)
 
-    program.runSafe.runOption.run ==== Option((Right(if (isEven(n)) n else 1), List(finalBoom)))
+    program.runSafe.run ==== (Right(if (isEven(n)) n else 1) -> List(finalBoom))
   }.setGen(genInt)
 
   def ignoreException1 = prop { n: Int =>
-    def runWithException(t: Throwable): Option[Throwable Either Unit] =
-      protect[S, Int](throw t).ignoreException[IllegalArgumentException].execSafe.runOption.run
+    def runWithException(t: Throwable): Throwable Either Unit =
+      protect[S, Int](throw t).ignoreException[IllegalArgumentException].execSafe.run
 
-    runWithException(boom) must beSome(beLeft[Throwable])
-    runWithException(new IllegalArgumentException("ok")) must beSome(beRight[Unit])
+    runWithException(boom) ==== Left(boom)
+    runWithException(new IllegalArgumentException("ok")) must beRight[Unit]
   }
+
+  def whenThrowable1 = prop { n: Int =>
+    def runWithException(t: Throwable): Throwable Either Int =
+      protect[S, Int](throw t).whenThrowable {
+        case _: IllegalArgumentException => pure(0)
+        case _: IllegalStateException => pure(1)
+      }.execSafe.run
+
+    runWithException(boom) ==== Left(boom)
+    runWithException(new IllegalArgumentException("ok")) ==== Right(0)
+    runWithException(new IllegalStateException("ok")) ==== Right(1)
+  }
+
+  def mixedWithOtherEffects1 = prop { n: Int =>
+
+    type SOE = Fx.fx3[Safe, Option, Eval]
+
+    def filter(x: Int): Option[Int] = if (x == 10) None else Some(x)
+
+    def action(x: Int): Int =
+      if (x == 3) throw new IllegalArgumentException
+      else if (x == 5) throw new IllegalStateException("too odd")
+      else x
+
+    val program = for {
+      dn <- EvalEffect.delay[SOE, Int](n)
+      fdn <- OptionEffect.fromOption[SOE, Int](filter(dn))
+      pdn <- protect[SOE, Int](action(fdn)).whenThrowable {
+        case _: IllegalArgumentException => pure(-1)
+      }
+    } yield pdn
+
+    val result = program.runEval.execSafe.runOption.run
+    result match {
+      case None =>
+        n ==== 10
+      case Some(Left(ise: IllegalStateException)) =>
+        n ==== 5
+        ise.getMessage ==== "too odd"
+      case Some(Right(-1)) =>
+        n ==== 3
+      case Some(Right(x)) =>
+        n ==== x
+      case _ => ok
+    }
+  }.setGen(genInt)
 
   /**
    * HELPERS

--- a/shared/src/main/scala/org/atnos/eff/syntax/safe.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/safe.scala
@@ -25,11 +25,17 @@ trait safe {
     def catchThrowable[B](pure: A => B, onThrowable: Throwable => Eff[R, B])(implicit m: Safe /= R): Eff[R, B] =
       SafeEffect.catchThrowable(e, pure, onThrowable)
 
+    def recoverThrowable[B](pure: A => B, onThrowable: PartialFunction[Throwable, Eff[R, B]])(implicit m: Safe /= R): Eff[R, B] =
+      SafeEffect.recoverThrowable(e, pure, onThrowable)
+
     def otherwise(onThrowable: Eff[R, A])(implicit m: Safe /= R): Eff[R, A] =
       SafeEffect.otherwise(e, onThrowable)
 
     def whenFailed(onThrowable: Throwable => Eff[R, A])(implicit m: Safe /= R): Eff[R, A] =
       SafeEffect.whenFailed(e, onThrowable)
+
+    def whenThrowable(onThrowable: PartialFunction[Throwable, Eff[R, A]])(implicit m: Safe /= R): Eff[R, A] =
+      SafeEffect.whenThrowable(e, onThrowable)
 
     def attempt(implicit m: Safe /= R): Eff[R, Throwable Either A] =
       SafeEffect.attempt(e)


### PR DESCRIPTION
couple changes here
- allow to catch and handle only specific exceptions (like it's possible with try/catch)
- changing SafeSpec to use only Safe effect - I was reading the spec to understand methods better and didn't get why option effect is needed there. Let me know if it was there for a purpose and i can resurrect it