### PR TITLE
Disable tests in JavaScript by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,12 @@ lazy val commonJsSettings = Seq(
   requiresDOM := false,
   libraryDependencies ++= catsJs,
   jsEnv := NodeJSEnv().value
+) ++ disableTests
+
+def disableTests = Seq(
+  test := {},
+  testQuick := {},
+  testOnly := {}
 )
 
 lazy val commonJvmSettings = Seq(


### PR DESCRIPTION
Until specs2 supports it. This consistently removes two seconds of overhead from `test` and `testQuick` (on my laptop), because starting three `node` instances is just that slow 😉