### PR TITLE
Makes Unions use Vector instead of List for asymptotic reasons

### DIFF
--- a/fs2/shared/src/main/scala/org/atnos/eff/addon/fs2/TaskEffect.scala
+++ b/fs2/shared/src/main/scala/org/atnos/eff/addon/fs2/TaskEffect.scala
@@ -147,7 +147,7 @@ trait TaskInterpretation extends TaskTypes {
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
         val collected = unions.extract(task)
-        val continuation1 = Arrs.singleton[R, List[Any], Throwable Either A] { ls: List[Any] =>
+        val continuation1 = Arrs.singleton[R, Vector[Any], Throwable Either A] { ls: Vector[Any] =>
           val xors =
             ls.zipWithIndex.collect { case (a, i) =>
               if (collected.indices.contains(i)) a.asInstanceOf[Throwable Either Any]
@@ -197,7 +197,7 @@ trait TaskInterpretation extends TaskTypes {
         val materializedUnions =
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
-        val continuation1 = Arrs.singleton[R, List[Any], A]((ls: List[Any]) => taskMemo(key, cache, continuation(ls)))
+        val continuation1 = Arrs.singleton[R, Vector[Any], A]((ls: Vector[Any]) => taskMemo(key, cache, continuation(ls)))
         ImpureAp(materializedUnions, continuation1, last)
     }
   }

--- a/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
+++ b/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
@@ -156,7 +156,7 @@ trait TaskInterpretation extends TaskTypes {
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
         val collected = unions.extract(task)
-        val continuation1 = Arrs.singleton[R, List[Any], Throwable Either A] { ls: List[Any] =>
+        val continuation1 = Arrs.singleton[R, Vector[Any], Throwable Either A] { ls: Vector[Any] =>
           val xors =
             ls.zipWithIndex.collect { case (a, i) =>
               if (collected.indices.contains(i)) a.asInstanceOf[Throwable Either Any]
@@ -206,7 +206,7 @@ trait TaskInterpretation extends TaskTypes {
         val materializedUnions =
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
-        val continuation1 = Arrs.singleton[R, List[Any], A]((ls: List[Any]) => taskMemo(key, cache, continuation(ls)))
+        val continuation1 = Arrs.singleton[R, Vector[Any], A]((ls: Vector[Any]) => taskMemo(key, cache, continuation(ls)))
         ImpureAp(materializedUnions, continuation1, last)
     }
   }

--- a/scalaz/src/main/scala/org/atnos/eff/addon/scalaz/concurrent/TaskEffect.scala
+++ b/scalaz/src/main/scala/org/atnos/eff/addon/scalaz/concurrent/TaskEffect.scala
@@ -151,7 +151,7 @@ trait TaskInterpretation extends TaskTypes {
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
         val collected = unions.extract(async)
-        val continuation1 = Arrs.singleton[R, List[Any], Throwable Either A] { ls: List[Any] =>
+        val continuation1 = Arrs.singleton[R, Vector[Any], Throwable Either A] { ls: Vector[Any] =>
           val xors =
             ls.zipWithIndex.collect { case (a, i) =>
               if (collected.indices.contains(i)) a.asInstanceOf[Throwable Either Any]
@@ -200,7 +200,7 @@ trait TaskInterpretation extends TaskTypes {
         val materializedUnions =
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
-        val continuation1 = Arrs.singleton[R, List[Any], A]((ls: List[Any]) => taskMemo(key, cache, continuation(ls)))
+        val continuation1 = Arrs.singleton[R, Vector[Any], A]((ls: Vector[Any]) => taskMemo(key, cache, continuation(ls)))
         ImpureAp(materializedUnions, continuation1, last)
     }
   }

--- a/shared/src/main/scala/org/atnos/eff/AsyncEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/AsyncEffect.scala
@@ -91,7 +91,7 @@ trait AsyncInterpretation {
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
         val collected = unions.extract(async)
-        val continuation1 = Arrs.singleton[R, List[Any], Throwable Either A] { ls: List[Any] =>
+        val continuation1 = Arrs.singleton[R, Vector[Any], Throwable Either A] { ls: Vector[Any] =>
           val xors =
             ls.zipWithIndex.collect { case (a, i) =>
               if (collected.indices.contains(i)) a.asInstanceOf[Throwable Either Any]

--- a/shared/src/main/scala/org/atnos/eff/FutureEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/FutureEffect.scala
@@ -130,7 +130,7 @@ trait FutureInterpretation extends FutureTypes {
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
         val collected = unions.extract(future)
-        val continuation1 = Arrs.singleton[R, List[Any], Throwable Either A] { ls: List[Any] =>
+        val continuation1 = Arrs.singleton[R, Vector[Any], Throwable Either A] { ls: Vector[Any] =>
           val xors =
             ls.zipWithIndex.collect { case (a, i) =>
               if (collected.indices.contains(i)) a.asInstanceOf[Throwable Either Any]
@@ -197,7 +197,7 @@ trait FutureInterpretation extends FutureTypes {
         val materializedUnions =
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
-        val continuation1 = Arrs.singleton[R, List[Any], A]((ls: List[Any]) => futureMemo(key, cache, continuation(ls)))
+        val continuation1 = Arrs.singleton[R, Vector[Any], A]((ls: Vector[Any]) => futureMemo(key, cache, continuation(ls)))
         ImpureAp(materializedUnions, continuation1, last)
     }
   }

--- a/shared/src/main/scala/org/atnos/eff/Interpret.scala
+++ b/shared/src/main/scala/org/atnos/eff/Interpret.scala
@@ -438,7 +438,7 @@ trait Interpret {
               if (collected.effects.isEmpty)
                 collected.othersEff(Arrs.singleton(x => goLast(Last.eff(continuation(x).addLast(last)))))
               else {
-                val translated: Eff[U, List[Any]] = EffApplicative.traverse(collected.effects)(tr.apply)
+                val translated: Eff[U, Vector[Any]] = EffApplicative.traverse(collected.effects)(tr.apply)
                 translated.flatMap(ls => goLast(Last.eff(collected.continuation(continuation, m).apply(ls).addLast(last))))
               }
           }
@@ -464,7 +464,7 @@ trait Interpret {
           if (collected.effects.isEmpty)
             collected.othersEff(Arrs.singleton(x => go(continuation(x).addLast(last))))
           else {
-            val translated: Eff[U, List[Any]] = EffApplicative.traverse(collected.effects)(tr.apply)
+            val translated: Eff[U, Vector[Any]] = EffApplicative.traverse(collected.effects)(tr.apply)
             translated.flatMap(ls => translate(collected.continuation(continuation, m).apply(ls).addLast(last))(tr))
           }
       }
@@ -502,7 +502,7 @@ trait Interpret {
               }
 
             case ap @ ImpureAp(unions, continuation, last) =>
-              val translated: Eff[U, List[Any]] = Eff.traverseA(unions.extract.effects)(tx => translate(tx).addLast(goLast(last)))
+              val translated: Eff[U, Vector[Any]] = Eff.traverseA(unions.extract.effects)(tx => translate(tx).addLast(goLast(last)))
               translated.flatMap(ts => goLast(Last.eff(continuation(ts).addLast(last))))
           }
       }
@@ -517,7 +517,7 @@ trait Interpret {
         }
 
       case ImpureAp(unions, c, last) =>
-        val translated: Eff[U, List[Any]] = Eff.traverseA(unions.extract.effects)(tx => translate(tx).addLast(goLast(last)))
+        val translated: Eff[U, Vector[Any]] = Eff.traverseA(unions.extract.effects)(tx => translate(tx).addLast(goLast(last)))
         translated.flatMap(ts => translateInto(c(ts).addLast(last))(translate))
     }
   }

--- a/shared/src/main/scala/org/atnos/eff/IntoPoly.scala
+++ b/shared/src/main/scala/org/atnos/eff/IntoPoly.scala
@@ -233,7 +233,7 @@ trait IntoPolyLower5 {
 
         case ImpureAp(unions, c, l) =>
           ImpureAp(unions.into(new UnionInto[U, R] { def apply[X](u: Union[U, X]) = m.accept(u) }),
-            Arrs.singleton((xs: List[Any]) => intoMember.apply(c(xs))), l.interpret(apply))
+            Arrs.singleton((xs: Vector[Any]) => intoMember.apply(c(xs))), l.interpret(apply))
       }
   }
 }

--- a/shared/src/main/scala/org/atnos/eff/SubscribeEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/SubscribeEffect.scala
@@ -106,7 +106,7 @@ object SubscribeEffect {
         val materializedUnions =
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
-        val continuation1 = Arrs.singleton[FS, List[Any], A]((ls: List[Any]) => memoizeSubsequence(key, sequenceKey, sub, cache, continuation(ls)))
+        val continuation1 = Arrs.singleton[FS, Vector[Any], A]((ls: Vector[Any]) => memoizeSubsequence(key, sequenceKey, sub, cache, continuation(ls)))
         ImpureAp(materializedUnions, continuation1, last)
     }
   }

--- a/shared/src/main/scala/org/atnos/eff/Unions.scala
+++ b/shared/src/main/scala/org/atnos/eff/Unions.scala
@@ -7,13 +7,13 @@ import cats._
  *
  * It is only partially typed, we just keep track of the type of the first object
  */
-case class Unions[R, A](first: Union[R, A], rest: List[Union[R, Any]]) {
+case class Unions[R, A](first: Union[R, A], rest: Vector[Union[R, Any]]) {
   type X = A
 
   def size: Int =
     rest.size + 1
 
-  def unions: List[Union[R, Any]]=
+  def unions: Vector[Union[R, Any]]=
     first.asInstanceOf[Union[R, Any]] +: rest
 
   def append[B](others: Unions[R, B]): Unions[R, A] =
@@ -23,11 +23,11 @@ case class Unions[R, A](first: Union[R, A], rest: List[Union[R, Any]]) {
    * create a continuation which will apply the 'map' function
    * if the first effect of this Unions object is interpreted
    */
-  def continueWith[B](continuation: Arrs[R, List[Any], B]): Arrs[R, A, B] =
+  def continueWith[B](continuation: Arrs[R, Vector[Any], B]): Arrs[R, A, B] =
   Arrs.singleton { (x: X) =>
     rest match {
-      case Nil    => continuation(x :: Nil)
-      case h :: t => ImpureAp[R, h.X, B](Unions[R, h.X](h, t), Arrs.singleton((ys: List[Any]) => continuation(x :: ys)))
+      case v if v.isEmpty => continuation(x +: Vector.empty)
+      case h +: t         => ImpureAp[R, h.X, B](Unions[R, h.X](h, t), Arrs.singleton((ys: Vector[Any]) => continuation(x +: ys)))
     }
   }
 
@@ -53,7 +53,7 @@ case class Unions[R, A](first: Union[R, A], rest: List[Union[R, Any]]) {
 
   private def collect[M[_], U](collect: Union[R, Any] => Union[U, Any] Either M[Any]): CollectedUnions[M, R, U] = {
     val (effectsAndIndices, othersAndIndices) =
-      unions.zipWithIndex.foldLeft((Vector[(M[Any], Int)](), Vector[(Union[U, Any], Int)]())) {
+      unions.iterator.zipWithIndex.foldLeft((Vector[(M[Any], Int)](), Vector[(Union[U, Any], Int)]())) {
         case ((es, os), (u, i)) =>
           collect(u) match {
             case Right(mx) => (es :+ ((mx, i)), os)
@@ -61,8 +61,8 @@ case class Unions[R, A](first: Union[R, A], rest: List[Union[R, Any]]) {
           }
       }
 
-    val (effects, indices) = effectsAndIndices.toList.unzip
-    val (otherEffects, otherIndices) = othersAndIndices.toList.unzip
+    val (effects, indices) = effectsAndIndices.unzip
+    val (otherEffects, otherIndices) = othersAndIndices.unzip
 
     CollectedUnions[M, R, U](effects, otherEffects, indices, otherIndices)
   }
@@ -76,33 +76,33 @@ case class Unions[R, A](first: Union[R, A], rest: List[Union[R, Any]]) {
 
 object Unions {
   def send[M[_], R, X](mx: M[X])(implicit m: MemberIn[M, R]) =
-    Unions[R, X](m.inject(mx), Nil)
+    Unions[R, X](m.inject(mx), Vector.empty)
 }
 
 /**
  * Collection of effects of a given type from a Unions objects
  *
  */
-case class CollectedUnions[M[_], R, U](effects: List[M[Any]], otherEffects: List[Union[U, Any]], indices: List[Int], otherIndices: List[Int]) {
-  def continuation[A](continueWith: List[Any] => Eff[R, A], m: Member.Aux[M, R, U]): Arrs[R, List[Any], A] =
+case class CollectedUnions[M[_], R, U](effects: Vector[M[Any]], otherEffects: Vector[Union[U, Any]], indices: Vector[Int], otherIndices: Vector[Int]) {
+  def continuation[A](continueWith: Vector[Any] => Eff[R, A], m: Member.Aux[M, R, U]): Arrs[R, Vector[Any], A] =
     otherEffects match {
-      case Nil       => Arrs.singleton[R, List[Any], A](ls => continueWith(ls))
-      case o :: rest => Arrs.singleton[R, List[Any], A](ls => ImpureAp[R, Any, A](Unions(m.accept(o), rest.map(m.accept)), Arrs.singleton(xs => continueWith(reorder(ls, xs)))))
+      case v if v.isEmpty => Arrs.singleton[R, Vector[Any], A](ls => continueWith(ls))
+      case o +: rest      => Arrs.singleton[R, Vector[Any], A](ls => ImpureAp[R, Any, A](Unions(m.accept(o), rest.map(m.accept)), Arrs.singleton(xs => continueWith(reorder(ls, xs)))))
     }
 
-  def continuation[A](continueWith: Arrs[U, List[Any], A]): Arrs[U, List[Any], A] =
+  def continuation[A](continueWith: Arrs[U, Vector[Any], A]): Arrs[U, Vector[Any], A] =
     otherEffects match {
-      case Nil       => continueWith
-      case o :: rest => Arrs.singleton[U, List[Any], A](ls => ImpureAp[U, Any, A](Unions(o, rest), Arrs.singleton(xs => continueWith(reorder(ls, xs)))))
+      case v if v.isEmpty => continueWith
+      case o +: rest      => Arrs.singleton[U, Vector[Any], A](ls => ImpureAp[U, Any, A](Unions(o, rest), Arrs.singleton(xs => continueWith(reorder(ls, xs)))))
     }
 
-  def othersEff[A](continueWith: Arrs[U, List[Any], A]): Eff[U, A] =
+  def othersEff[A](continueWith: Arrs[U, Vector[Any], A]): Eff[U, A] =
     otherEffects match {
-      case Nil       => continueWith(Nil)
-      case o :: rest => ImpureAp[U, Any, A](Unions(o, rest), Arrs.singleton(ls => continueWith(ls)))
+      case v if v.isEmpty => continueWith(Vector.empty)
+      case o +: rest      => ImpureAp[U, Any, A](Unions(o, rest), Arrs.singleton(ls => continueWith(ls)))
     }
 
-  private def reorder(ls: List[Any], xs: List[Any]): List[Any] =
+  private def reorder(ls: Vector[Any], xs: Vector[Any]): Vector[Any] =
     (ls.zip(indices) ++ xs.zip(otherIndices)).sortBy(_._2).map(_._1)
 
 }

--- a/twitter/src/main/scala/org/atnos/eff/addon/twitter/TwitterFutureEffect.scala
+++ b/twitter/src/main/scala/org/atnos/eff/addon/twitter/TwitterFutureEffect.scala
@@ -132,7 +132,7 @@ trait TwitterFutureInterpretation extends TwitterFutureTypes {
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
         val collected = unions.extract(future)
-        val continuation1 = Arrs.singleton[R, List[Any], Throwable Either A] { ls: List[Any] =>
+        val continuation1 = Arrs.singleton[R, Vector[Any], Throwable Either A] { ls: Vector[Any] =>
           val xors =
             ls.zipWithIndex.collect { case (a, i) =>
               if (collected.indices.contains(i)) a.asInstanceOf[Throwable Either Any]
@@ -195,7 +195,7 @@ trait TwitterFutureInterpretation extends TwitterFutureTypes {
         val materializedUnions =
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
-        val continuation1 = Arrs.singleton[R, List[Any], A]((ls: List[Any]) => futureMemo(key, cache, continuation(ls)))
+        val continuation1 = Arrs.singleton[R, Vector[Any], A]((ls: Vector[Any]) => futureMemo(key, cache, continuation(ls)))
         ImpureAp(materializedUnions, continuation1, last)
     }
   }


### PR DESCRIPTION
`ap` has linear complexity, and `traverse` quadratic, if we use `List` in `Unions` and rely on `List` appending for `ap` concatenation. `Vector` can fix this; perhaps eventually `Vector` should be replaced with something `Catenable` for more performance. #