### PR TITLE
Indexed coproducts

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
@@ -349,8 +349,8 @@ class EffSpec extends Specification with ScalaCheck { def is = s2"""
     def runDsl[A](eff: Eff[Fx1[UserDsl], A]): A =
       eff match {
         case Pure(a,_) => a
-        case Impure(Union1(GetUser(i)), c, _)   => runDsl(c(getWebUser(i)))
-        case Impure(Union1(GetUsers(is)), c, _) => runDsl(c(getWebUsers(is)))
+        case Impure(UnionTagged(GetUser(i), _), c, _)   => runDsl(c(getWebUser(i)))
+        case Impure(UnionTagged(GetUsers(is), _), c, _) => runDsl(c(getWebUsers(is)))
         case ap @ ImpureAp(u, m, _)             => runDsl(ap.toMonadic)
       }
 

--- a/jvm/src/test/scala/org/atnos/eff/MemberImplicitsSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/MemberImplicitsSpec.scala
@@ -36,9 +36,9 @@ class MemberImplicitsSpec extends Specification { def is = s2"""
   implicit class RunNOps[T[_] <: OptionN[_], R, A](e: Eff[R, A]) {
     def runN[U](implicit m: Member.Aux[T, R, U]): Eff[U, A] =
       e match {
-        case Pure(a) => Eff.pure[U, A](a)
-        case Impure(u, c) => Eff.pure[U, A](m.project(u).toOption.get.asInstanceOf[A])
-        case ImpureAp(unions, map) => Eff.pure[U, A](map(unions.unions.map(u => m.project(u).toOption.get.a)))
+        case Pure(a, _) => Eff.pure[U, A](a)
+        case Impure(u, c, _) => Eff.pure[U, A](m.project(u).toOption.get.asInstanceOf[A])
+        case ap@ImpureAp(unions, map, _) => new RunNOps(ap.toMonadic).runN
       }
   }
 

--- a/jvm/src/test/scala/org/atnos/eff/MemberSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/MemberSpec.scala
@@ -12,32 +12,60 @@ import syntax.all._
 
 class MemberSpec extends Specification with ScalaCheck { def is = s2"""
 
- inject / project must work at the value level
-   for reader $reader
-   for writer $writer
-   for eval   $eval
+for 3-element stacks:
 
- extract . inject === Option.apply $lawMemberIn
- project fold (accept, inject) === identity $lawMember
+   inject / project must work at the value level
+     for reader $reader3
+     for writer $writer3
+     for eval   $eval3
+
+   extract . inject === Option.apply $lawMemberIn3
+   project fold (accept, inject) === identity $lawMember3
+
+for 4-element stacks:
+
+   inject / project must work at the value level
+     for reader $reader4
+     for writer $writer4
+     for eval   $eval4
+
+   extract . inject === Option.apply $lawMemberIn4
+   project fold (accept, inject) === identity $lawMember4
 
  A MemberIn instance can be transformed with natural transformations    $natIn
  A MemberInOut instance can be transformed with natural transformations $natInOut
 
 """
 
-  def reader =
-    readerMember.project(readerMember.inject(read1)) must beRight(read1)
+  def reader3 =
+    readerMember3.project(readerMember3.inject(read1)) must beRight(read1)
 
-  def writer =
-    writerMember.project(writerMember.inject(write1)) must beRight(write1)
+  def writer3 =
+    writerMember3.project(writerMember3.inject(write1)) must beRight(write1)
 
-  def eval =
-    evalMember.project(evalMember.inject(eval1)) must beRight(eval1)
+  def eval3 =
+    evalMember3.project(evalMember3.inject(eval1)) must beRight(eval1)
 
-  def lawMemberIn =
-    writerMember.extract(writerMember.inject(write1)) ==== Option(write1)
+  def lawMemberIn3 =
+    writerMember3.extract(writerMember3.inject(write1)) ==== Option(write1)
 
-  def lawMember = Prop.forAll(genUnion, genMember) { (union: Union[S, String], m: SMember) =>
+  def lawMember3 = Prop.forAll(genUnion3, genMember3) { (union: Union[S3, String], m: SMember3) =>
+    m.member.project(union).fold(m.member.accept, m.member.inject) ==== union
+  }
+
+  def reader4 =
+    readerMember4.project(readerMember4.inject(read1)) must beRight(read1)
+
+  def writer4 =
+    writerMember4.project(writerMember4.inject(write1)) must beRight(write1)
+
+  def eval4 =
+    evalMember4.project(evalMember4.inject(eval1)) must beRight(eval1)
+
+  def lawMemberIn4 =
+    writerMember4.extract(writerMember4.inject(write1)) ==== Option(write1)
+
+  def lawMember4 = Prop.forAll(genUnion4, genMember4) { (union: Union[S4, String], m: SMember4) =>
     m.member.project(union).fold(m.member.accept, m.member.inject) ==== union
   }
 
@@ -53,44 +81,70 @@ class MemberSpec extends Specification with ScalaCheck { def is = s2"""
   type WriterString[A] = Writer[String, A]
   type ReaderInt[A] = Reader[Int, A]
 
-  type S = Fx3[WriterString, ReaderInt, Eval]
+  type S3 = Fx3[WriterString, ReaderInt, Eval]
+  type S4 = FxAppend[Fx3[WriterString, ReaderInt, Eval], NoFx]
 
-  def writerMember =
+  def writerMember3 =
     Member.Member3L[WriterString, ReaderInt, Eval]
 
-  def readerMember =
+  def readerMember3 =
     Member.Member3M[WriterString, ReaderInt, Eval]
 
-  def evalMember: Member.Aux[Eval, S, Fx2[WriterString, ReaderInt]] =
+  def evalMember3: Member.Aux[Eval, S3, Fx2[WriterString, ReaderInt]] =
     Member.Member3R[WriterString, ReaderInt, Eval]
+
+  def writerMember4: Member.Aux[WriterString, FxAppend[Fx3[WriterString, ReaderInt, Eval], NoFx], FxAppend[Fx2[ReaderInt, Eval], NoFx]] =
+    Member.MemberAppendL(writerMember3)
+
+  def readerMember4: Member.Aux[ReaderInt, FxAppend[Fx3[WriterString, ReaderInt, Eval], NoFx], FxAppend[Fx2[WriterString, Eval], NoFx]] =
+    Member.MemberAppendL(readerMember3)
+
+  def evalMember4: Member.Aux[Eval, FxAppend[S3, NoFx], FxAppend[Fx2[WriterString, ReaderInt], NoFx]] =
+    Member.MemberAppendL(evalMember3)
 
   val read1  = Reader((i: Int) => "hey")
   val write1 = Writer[String, String]("hey", "hey")
   val eval1  = Eval.later("hey")
 
-  trait SMember {
+  trait SMember3 {
     type T[_]
-    val member: Member[T, S]
-
+    val member: Member[T, S3]
   }
 
-  def genUnion: Gen[Union[S, String]] =
-    Gen.oneOf(
-      writerMember.inject(write1),
-      evalMember.inject(eval1),
-      readerMember.inject(read1))
+  trait SMember4 {
+    type T[_]
+    val member: Member[T, S4]
+  }
 
-  def genMember[T[_]]: Gen[SMember] =
+  def genUnion3: Gen[Union[S3, String]] =
     Gen.oneOf(
-      new SMember { type T[A] = WriterString[A]; val member = writerMember } ,
-      new SMember { type T[A] = Eval[A];         val member = evalMember } ,
-      new SMember { type T[A] = ReaderInt[A];    val member = readerMember })
+      writerMember3.inject(write1),
+      evalMember3.inject(eval1),
+      readerMember3.inject(read1))
+
+  def genMember3[T[_]]: Gen[SMember3] =
+    Gen.oneOf(
+      new SMember3 { type T[A] = WriterString[A]; val member = writerMember3 } ,
+      new SMember3 { type T[A] = Eval[A];         val member = evalMember3 } ,
+      new SMember3 { type T[A] = ReaderInt[A];    val member = readerMember3 })
+
+  def genUnion4: Gen[Union[S4, String]] =
+    Gen.oneOf(
+      writerMember4.inject(write1),
+      evalMember4.inject(eval1),
+      readerMember4.inject(read1))
+
+  def genMember4[T[_]]: Gen[SMember4] =
+    Gen.oneOf(
+      new SMember4 { type T[A] = WriterString[A]; val member = writerMember4 } ,
+      new SMember4 { type T[A] = Eval[A];         val member = evalMember4 } ,
+      new SMember4 { type T[A] = ReaderInt[A];    val member = readerMember4 })
 
   type readStr[E] = Reader[String, ?] |= E
   type stateStr[E] = State[String, ?] |= E
 
   type ReadStr[E] = Reader[String, ?] /= E
-  type RtateStr[E] = State[String, ?] /= E
+  type StateStr[E] = State[String, ?] /= E
 
   implicit def readerStateNat[S1] = new (Reader[S1, ?] ~> State[S1, ?]) {
     def apply[X](r: Reader[S1, X]): State[S1, X] =

--- a/jvm/src/test/scala/org/atnos/site/ApplicativeEvaluation.scala
+++ b/jvm/src/test/scala/org/atnos/site/ApplicativeEvaluation.scala
@@ -109,8 +109,8 @@ def runDsl[A](eff: Eff[Fx1[UserDsl], A]): (A, Vector[String]) = {
   def go(e: Eff[Fx1[UserDsl], A], trace: Vector[String]): (A, Vector[String]) =
     e match {
       case Pure(a,_) => (a, trace)
-      case Impure(Union1(GetUser(i)), c, _)   => go(c(getWebUser(i)), trace :+ "getWebUser")
-      case Impure(Union1(GetUsers(is)), c, _) => go(c(getWebUsers(is)), trace :+ "getWebUsers")
+      case Impure(UnionTagged(GetUser(i), _), c, _)   => go(c(getWebUser(i)), trace :+ "getWebUser")
+      case Impure(UnionTagged(GetUsers(is), _), c, _) => go(c(getWebUsers(is)), trace :+ "getWebUsers")
       case ap @ ImpureAp(_, _, _)             => go(ap.toMonadic, trace)
   }
   go(eff, Vector())

--- a/scalaz/src/main/scala/org/atnos/eff/addon/scalaz/package.scala
+++ b/scalaz/src/main/scala/org/atnos/eff/addon/scalaz/package.scala
@@ -61,14 +61,14 @@ package object scalaz {
 
         case Impure(u, continuation, last) =>
           u match {
-            case Union1(ta) =>
+            case UnionTagged(ta: M[Nothing] @unchecked, _) =>
               last match {
                 case Last(Some(l)) => Monad[M].map(ta)(x => -\/(continuation(x).addLast(last)))
                 case Last(None)    => Monad[M].map(ta)(x => -\/(continuation(x)))
               }
           }
 
-        case ap @ ImpureAp(u, continuation, last) =>
+        case ap @ ImpureAp(_, _, _) =>
           Monad[M].point(-\/(ap.toMonadic))
       }(eff)
 
@@ -79,7 +79,7 @@ package object scalaz {
 
         case Impure(u, continuation, last) =>
           u match {
-            case Union1(ta) =>
+            case UnionTagged(ta: M[Nothing] @unchecked, _) =>
               last match {
                 case Last(Some(l)) => Monad[M].map(ta)(x => -\/(continuation(x).addLast(last)))
                 case Last(None)    => Monad[M].map(ta)(x => -\/(continuation(x)))
@@ -87,8 +87,8 @@ package object scalaz {
           }
 
         case ap @ ImpureAp(unions, continuation, last) =>
-          val effects = unions.unions.collect { case Union1(mx) => mx }
-          val sequenced = applicative.sequence(effects)
+          val effects = unions.unions.collect { case UnionTagged(mx: M[Nothing] @unchecked, _) => mx }
+          val sequenced = applicative.sequence[Nothing, Vector](effects)
 
           last match {
             case Last(Some(l)) => Monad[M].map(sequenced)(x => -\/(continuation(x).addLast(last)))

--- a/shared/src/main/scala/org/atnos/eff/Arrs.scala
+++ b/shared/src/main/scala/org/atnos/eff/Arrs.scala
@@ -71,12 +71,11 @@ case class Arrs[R, A, B](functions: Vector[Any => Eff[R, Any]]) extends (A => Ef
   def contramap[C](f: C => A): Arrs[R, C, B] =
     Arrs(((c: Any) => Eff.pure[R, Any](f(c.asInstanceOf[C]).asInstanceOf[Any])) +: functions)
 
-  def contraFlatMap[C](f: C => Eff[R, A]): Arrs[R, C, B] = {
-      Arrs(f.asInstanceOf[Any => Eff[R, Any]] +: functions)
-  }
+  def contraFlatMap[C](f: C => Eff[R, A]): Arrs[R, C, B] =
+    Arrs(f.asInstanceOf[Any => Eff[R, Any]] +: functions)
 
   def transform[U, M[_], N[_]](t: ~>[M, N])(implicit m: Member.Aux[M, R, U], n: Member.Aux[N, R, U]): Arrs[R, A, B] =
-    Arrs(functions.map(f => (x: Any) => Interpret.transform(f(x), t)(m, n)))
+    Arrs(functions.map(f => (x: Any) => Interpret.transform(f(x): Eff[R, Any], t)(m, n)))
 }
 
 object Arrs {

--- a/shared/src/main/scala/org/atnos/eff/AsyncEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/AsyncEffect.scala
@@ -239,13 +239,7 @@ object Async {
               case Right(b) => AsyncNow[B](b)
             }
 
-            case imp @ Impure(u, c, last) =>
-              AsyncEff(imp.flatMap {
-                case Left(a1) => subscribeAsync(tailRecM(a1)(f))
-                case Right(b) => Eff.pure(b)
-              }, to)
-
-            case imp @ ImpureAp(unions, continuation, last) =>
+            case imp @ (Impure(_, _, _) | ImpureAp(_, _, _)) =>
               AsyncEff(imp.flatMap {
                 case Left(a1) => subscribeAsync(tailRecM(a1)(f))
                 case Right(b) => Eff.pure(b)

--- a/shared/src/main/scala/org/atnos/eff/EitherEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/EitherEffect.scala
@@ -173,7 +173,7 @@ trait EitherImplicits {
   implicit final def errorTranslate[R, E1, E2](implicit m: MemberIn[E1 Either ?, R], map: E2 => E1): MemberIn[E2 Either ?, R] =
     m.transform(errorTranslateNat(map))
 
-  def errorTranslateNat[E1, E2](map: E2 => E1): (E2 Either ?) ~> (E1 Either ?) = new ((E2 Either ?) ~> (E1 Either ?)) {
+  final def errorTranslateNat[E1, E2](map: E2 => E1): (E2 Either ?) ~> (E1 Either ?) = new ((E2 Either ?) ~> (E1 Either ?)) {
     def apply[X](x2: E2 Either X): E1 Either X = x2.leftMap(map)
   }
 

--- a/shared/src/main/scala/org/atnos/eff/Fx.scala
+++ b/shared/src/main/scala/org/atnos/eff/Fx.scala
@@ -1,7 +1,7 @@
 package org.atnos.eff
 
 /** one effect, basically a type constructor */
-sealed trait Effect[F[_]]
+sealed trait Effect[+F[_]]
 
 /**
  * Base type for a tree of effect types
@@ -37,13 +37,13 @@ object Fx {
 }
 
 /**
- * Append a  tree of effects to another one
+ * Append a tree of effects to another one
  */
-final case class FxAppend[L, R](left: L, right: R) extends Fx
+final case class FxAppend[+L, +R](left: L, right: R) extends Fx
 
-final case class Fx1[F[_]](e: Effect[F]) extends Fx
-final case class Fx2[L[_], R[_]](left: Effect[L], right: Effect[R]) extends Fx
-final case class Fx3[L[_], M[_], R[_]](left: Effect[L], middle: Effect[M], right: Effect[R]) extends Fx
+final case class Fx1[+F[_]](e: Effect[F]) extends Fx
+final case class Fx2[+L[_], +R[_]](left: Effect[L], right: Effect[R]) extends Fx
+final case class Fx3[+L[_], +M[_], +R[_]](left: Effect[L], middle: Effect[M], right: Effect[R]) extends Fx
 
 /**
  * The "empty" tree of effects

--- a/shared/src/main/scala/org/atnos/eff/Union.scala
+++ b/shared/src/main/scala/org/atnos/eff/Union.scala
@@ -3,31 +3,50 @@ package org.atnos.eff
 /**
  * Union represents one effect T[_] embedded in a tree of possible effects R
  *
- * Since the effect tree is represented with the following cases:
- *   - Fx1[T]
- *   - Fx2[T1, T2]
- *   - Fx3[T1, T2, T3]
+ * The effect tree is represented by four possible cases:
+ *   - fx1[T]
+ *   - fx2[T1, T2]
+ *   - fx3[T1, T2, T3]
  *   - FxAppend[L, R]
  *
- * We have the corresponding Union cases. For example
- *   T2 is in the "middle" of Fx3[T1, T2, T3] so creating a Union object for that effect uses Union3M
+ *  The union type has three concrete constructors:
+ *   - UnionAppendL(nested: Union[L]): Union[FxAppend[L, R]]
+ *   - UnionAppendR(nested: Union[R]): Union[FxAppend[L, R]]
+ *   - UnionTagged(valueUnsafe: Any, index: Int): Union[R] (for R in fx1, fx2, fx3...)
+ *  In that respect UnionTagged behaves similarly to a tagged union in C or C++.
+ *
  */
-sealed trait Union[+R, A] {
+trait Union[R, A] {
   type X = A
+  final private[eff] def forget[E, B]: Union[E, B] =
+    asInstanceOf[Union[E, B]]
+
+  final private[eff] def tagged: UnionTagged[R, A] =
+    this.asInstanceOf[UnionTagged[R, A]]
 }
+case class UnionTagged[R, A] (valueUnsafe: Any, index: Int) extends Union[R, A] {
+  private[eff] def increment[E]: Union[E, A] = copy(index = index + 1)
+  private[eff] def decrement[E]: Union[E, A] = copy(index = index - 1)
+}
+case class UnionAppendL[L, R, A](value: Union[L, A]) extends Union[FxAppend[L, R], A]
+case class UnionAppendR[L, R, A](value: Union[R, A]) extends Union[FxAppend[L, R], A]
 
-case class Union1[T[_], A](ta: T[A]) extends Union[Fx1[T], A]
-
-sealed trait Union2[R, A] extends Union[R, A]
-case class Union2L[L[_], R[_], A](t: L[A]) extends Union2[Fx2[L, R], A]
-case class Union2R[L[_], R[_], A](t: R[A]) extends Union2[Fx2[L, R], A]
-
-sealed trait Union3[R, A] extends Union[R, A]
-case class Union3L[L[_], M[_], R[_], A](t: L[A]) extends Union3[Fx3[L, M, R], A]
-case class Union3M[L[_], M[_], R[_], A](t: M[A]) extends Union3[Fx3[L, M, R], A]
-case class Union3R[L[_], M[_], R[_], A](t: R[A]) extends Union3[Fx3[L, M, R], A]
-
-sealed trait UnionAppend[R, A] extends Union[R, A]
-case class UnionAppendL[L, R, A](t: Union[L, A]) extends UnionAppend[FxAppend[L, R], A]
-case class UnionAppendR[L, R, A](t: Union[R, A]) extends UnionAppend[FxAppend[L, R], A]
+object Union {
+  def one[M[_], A](value: M[A]): Union[Fx1[M], A] =
+    UnionTagged(value, 1)
+  def twoL[M[_], T[_], A](value: M[A]): Union[Fx2[M, T], A] =
+    UnionTagged(value, 2)
+  def twoR[M[_], T[_], A](value: T[A]): Union[Fx2[M, T], A] =
+    UnionTagged(value, 1)
+  def threeL[M[_], T[_], N[_], A](value: M[A]): Union[Fx3[M, T, N], A] =
+    UnionTagged(value, 3)
+  def threeM[M[_], T[_], N[_], A](value: T[A]): Union[Fx3[M, T, N], A] =
+    UnionTagged(value, 2)
+  def threeR[M[_], T[_], N[_], A](value: N[A]): Union[Fx3[M, T, N], A] =
+    UnionTagged(value, 1)
+  def appendL[L, R, A](union: Union[L, A]): Union[FxAppend[L, R], A] =
+    UnionAppendL(union)
+  def appendR[L, R, A](union: Union[R, A]): Union[FxAppend[L, R], A] =
+    UnionAppendR(union)
+}
 

--- a/shared/src/main/scala/org/atnos/eff/WriterEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/WriterEffect.scala
@@ -42,7 +42,7 @@ trait WriterInterpretation {
    * This uses a ListBuffer internally to append values
    */
   def runWriter[R, U, O, A, B](w: Eff[R, A])(implicit m: Member.Aux[Writer[O, ?], R, U]): Eff[U, (A, List[O])] =
-    runWriterFold(w)(ListFold)
+    runWriterFold(w)(ListFold[O])
 
   /**
    * More general fold of runWriter where we can use a fold to accumulate values in a mutable buffer

--- a/shared/src/main/scala/org/atnos/eff/syntax/either.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/either.scala
@@ -12,7 +12,7 @@ trait either {
 final class EitherEffectOps[R, A](val e: Eff[R, A]) extends AnyVal {
 
   def runEither[E](implicit m: Member[(E Either ?), R]): Eff[m.Out, E Either A] =
-    EitherInterpretation.runEither(e)(m)
+    EitherInterpretation.runEither[R, m.Out, E, A](e)(m)
 
   def runEitherU[E, U](implicit m: Member.Aux[(E Either ?), R, U]): Eff[U, E Either A] =
     EitherInterpretation.runEither(e)(m)


### PR DESCRIPTION
Replaces `Union1`, `Union2L/R`, `Union3L/M/R` with a single representation `UnionTagged`, so that many anonymous implicits can be removed, some branches can be removed, and some `Member` and `IntoPoly` implicits can avoid allocating. I went with making indices increase from the right, starting at 1 on the right. So `Fx1[T] => Fx2[R, T]` is only a cast, for example.