### PR TITLE
Fix errors caused by more exhaustive matching in TLS 2.12.1

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/Union.scala
+++ b/shared/src/main/scala/org/atnos/eff/Union.scala
@@ -16,7 +16,7 @@ package org.atnos.eff
  *  In that respect UnionTagged behaves similarly to a tagged union in C or C++.
  *
  */
-trait Union[R, A] {
+sealed trait Union[R, A] {
   type X = A
   final private[eff] def forget[E, B]: Union[E, B] =
     asInstanceOf[Union[E, B]]


### PR DESCRIPTION
And get rid of a couple redundant `tagged match { case UnionTagged(_, _) }`.