### PR TITLE
Added a 'onNone' action on Arrs continuation to clean up resources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,8 +67,8 @@ lazy val scoverageSettings = Seq(
 
 lazy val buildSettings = Seq(
   organization := "org.atnos",
-  scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.11.8", "2.12.1")
+  scalaVersion := "2.12.1",
+  crossScalaVersions := Seq("2.11.8", scalaVersion.value)
 )
 
 lazy val commonSettings = Seq(

--- a/jvm/src/test/scala/org/atnos/eff/EffLastSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EffLastSpec.scala
@@ -1,0 +1,98 @@
+package org.atnos.eff
+
+import cats.Eval
+import org.specs2._
+import org.atnos.eff._
+import org.atnos.eff.all._
+import org.atnos.eff.syntax.all._
+import cats.implicits._
+import org.scalacheck.Gen
+
+import scala.collection.mutable.ListBuffer
+
+class EffLastSpec extends Specification with ScalaCheck { def is = isolated ^ s2"""
+
+  An action can run completely at the end, regardless of the number of flatmaps $runLast
+    now with one very last action which fails, there should be no exception     $runLastFail
+
+
+  bracket last triggers the last action regardless of the effects at play
+    either right + ok $e1
+    either right + protect exception $e2
+
+    either left + ok $e3
+    either left + protect exception $e4
+
+"""
+
+  def runLast = prop { xs: List[String] =>
+    type R = Fx.fx2[Safe, Eval]
+    val messages = new ListBuffer[String]
+
+    import org.atnos.eff.all._
+    import org.atnos.eff.syntax.all._
+
+    val act = for {
+      _ <- protect[R, Unit](messages.append("a")).addLast(protect[R, Unit](messages.append("end")))
+      _ <- protect[R, Unit](messages.append("b"))
+    } yield ()
+
+    act.runSafe.runEval.run
+
+    messages.toList ==== List("a", "b", "end")
+  }.setGen(Gen.listOf(Gen.oneOf("a", "b", "c")))
+
+  def runLastFail = prop { xs: List[String] =>
+    type R = Fx.fx2[Safe, Eval]
+    val messages = new ListBuffer[String]
+
+    import org.atnos.eff.all._
+    import org.atnos.eff.syntax.all._
+
+    val act = for {
+      _ <- protect[R, Unit](messages.append("a")).addLast(protect[R, Unit]{ messages.append("boom"); throw new Exception("boom")})
+      _ <- protect[R, Unit](messages.append("b"))
+    } yield ()
+
+    act.runSafe.runEval.run
+
+    messages.toList ==== List("a", "b", "boom")
+  }.setGen(Gen.listOf(Gen.oneOf("a", "b", "c")))
+
+  var i = 0
+
+  def e1 = checkRelease {
+    EitherEffect.right[S, String, Int](1) >>= (v => protect[S, Int](v))
+  }
+
+  def e2 = checkRelease {
+    EitherEffect.right[S, String, Int](1) >>= (v => protect[S, Int] { sys.error("ouch"); v })
+  }
+
+  def e3 = checkRelease {
+    EitherEffect.left[S, String, Int]("Error") >>= (v => protect[S, Int](v))
+  }
+
+  def e4 = checkRelease {
+    EitherEffect.left[S, String, Int]("Error") >>= (v => protect[S, Int] { sys.error("ouch"); v })
+  }
+
+  /**
+   * HELPERS
+   */
+  type _eitherString[R] = Either[String, ?] |= R
+
+  def acquire[R :_Safe]: Eff[R, Int] = protect[R, Int] { i += 1; i }
+  def release[R :_Safe]: Int => Eff[R, Int] = (_: Int) => protect[R, Int] { i -= 1; i }
+
+  def checkRelease(use: Eff[S, Int]) = {
+    eff(use).execSafe.flatMap(either => fromEither(either.leftMap(_.getMessage))).runEither.run
+    i ==== 0
+  }
+
+  def eff[R :_Safe :_eitherString](use: Eff[R, Int]): Eff[R, Int] =
+    bracketLast(acquire[R])(_ => use)(release[R])
+
+  type S = Fx.fx2[Safe, Either[String, ?]]
+
+}

--- a/shared/src/main/scala/org/atnos/eff/Batch.scala
+++ b/shared/src/main/scala/org/atnos/eff/Batch.scala
@@ -38,7 +38,7 @@ trait Batch {
               case e1 +: rest1 =>
                 ImpureAp(Unions(m.inject(e1), rest1.map(r => m.inject(r.asInstanceOf[T[Any]])) ++ collected.otherEffects),
                   // the map operation has to reorder the results based on what could be batched or not
-                  Arrs.singleton(ls => continuation(reorder(ls, result.hasBatched, result.keys ++ collected.otherIndices))), last)
+                  continuation.contramap(ls => reorder(ls, result.hasBatched, result.keys ++ collected.otherIndices)), last)
             }
         }
 

--- a/shared/src/main/scala/org/atnos/eff/Choose.scala
+++ b/shared/src/main/scala/org/atnos/eff/Choose.scala
@@ -83,7 +83,7 @@ trait ChooseInterpretation {
             case Impure(u, c, last) =>
               m.project(u) match {
                 case Left(u1) =>
-                  val r1 = Impure(u1, Arrs.singleton((x: u1.X) => runChoose[R, U, A, F](c(x)))).addLast(lastRun(last))
+                  val r1 = Impure(u1, c.interpret(runChoose[R, U, A, F])(_.interpret(l => runChoose[R, U, Unit, F](l).void))).addLast(lastRun(last))
                   go(rest, (r1 |@| result).map(alternativeF.combineK))
 
                 case Right(choose) =>

--- a/shared/src/main/scala/org/atnos/eff/IntoPoly.scala
+++ b/shared/src/main/scala/org/atnos/eff/IntoPoly.scala
@@ -52,10 +52,10 @@ trait IntoPolyLower2  extends IntoPolyLower3 {
             pure(a).addLast(last.interpret(apply))
 
           case Impure(u@UnionAppendR(r), c, l) =>
-            Impure[FxAppend[Fx2[T1, T2], R], u.X, A](Union.appendR(r), Arrs.singleton(x => apply(c(x))), l.interpret(apply))
+            Impure[FxAppend[Fx2[T1, T2], R], u.X, A](Union.appendR(r), c.interpretEff(apply)(apply), l.interpret(apply))
 
           case Impure(u@UnionAppendL(UnionTagged(value, _)), c, l) =>
-            Impure[FxAppend[Fx2[T1, T2], R], u.X, A](Union.appendL(Union.twoL(value.asInstanceOf[T1[A]])).forget, Arrs.singleton(x => apply(c(x))), l.interpret(apply))
+            Impure[FxAppend[Fx2[T1, T2], R], u.X, A](Union.appendL(Union.twoL(value.asInstanceOf[T1[A]])).forget, c.interpretEff(apply)(apply), l.interpret(apply))
 
           case Impure(_, _, _) => sys.error("impossible")
 
@@ -66,7 +66,7 @@ trait IntoPolyLower2  extends IntoPolyLower3 {
                   case UnionAppendR(r) => UnionAppendR(r)
                   case UnionAppendL(l) => UnionAppendL(Union.twoL(l.tagged.valueUnsafe.asInstanceOf[T1[X]]))
                   case UnionTagged(_, _) => sys.error("impossible")
-                }}), Arrs.singleton(x => apply(continuation(x))), last.interpret(apply))
+                }}), continuation.interpretEff(apply)(apply), last.interpret(apply))
         }
     }
 
@@ -84,13 +84,13 @@ trait IntoPolyLower2  extends IntoPolyLower3 {
             pure(a).addLast(last.interpret(apply))
 
           case Impure(u@UnionAppendR(_), c, l) =>
-            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](u.forget, Arrs.singleton(x => apply(c(x))), l.interpret(apply))
+            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](u.forget, c.interpretEff(apply)(apply), l.interpret(apply))
 
           case Impure(u@UnionAppendL(tagged@UnionTagged(_, 1)), c, l) =>
-            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](UnionAppendL(tagged.forget), Arrs.singleton(x => apply(c(x))), l.interpret(apply))
+            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](UnionAppendL(tagged.forget), c.interpretEff(apply)(apply), l.interpret(apply))
 
           case Impure(u@UnionAppendL(UnionTagged(value, 2)), c, l) =>
-            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](UnionAppendL(UnionTagged(value, 3)), Arrs.singleton(x => apply(c(x))), l.interpret(apply))
+            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](UnionAppendL(UnionTagged(value, 3)), c.interpretEff(apply)(apply), l.interpret(apply))
 
           case Impure(_, _, _) => sys.error("impossible")
 
@@ -106,7 +106,7 @@ trait IntoPolyLower2  extends IntoPolyLower3 {
                     else
                       tagged.increment
                   case UnionTagged(_, _) => sys.error("impossible")
-                }}), Arrs.singleton(x => apply(continuation(x))), last.interpret(apply))
+                }}), continuation.interpretEff(apply)(apply), last.interpret(apply))
         }
     }
 
@@ -118,11 +118,11 @@ trait IntoPolyLower2  extends IntoPolyLower3 {
             pure(a).addLast(last.interpret(apply))
 
           case Impure(u@UnionAppendR(r), c, l) =>
-            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](r.forget, Arrs.singleton(x => apply(c(x))), l.interpret(apply))
+            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](r.forget, c.interpretEff(apply)(apply), l.interpret(apply))
 
           case Impure(u@UnionAppendL(l), c, last) =>
             val tagged = l.tagged
-            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](UnionAppendL(tagged.increment), Arrs.singleton(x => apply(c(x))), last.interpret(apply))
+            Impure[FxAppend[Fx3[T1, T2, T3], R], u.X, A](UnionAppendL(tagged.increment), c.interpretEff(apply)(apply), last.interpret(apply))
 
           case Impure(_, _, _) => sys.error("impossible")
 
@@ -133,7 +133,7 @@ trait IntoPolyLower2  extends IntoPolyLower3 {
                   case UnionAppendR(r) => UnionAppendR(r)
                   case UnionAppendL(l) => UnionAppendL(l.tagged.increment)
                   case UnionTagged(_, _) => sys.error("impossible")
-                }}), Arrs.singleton(x => apply(continuation(x))), last.interpret(apply))
+                }}), continuation.interpretEff(apply)(apply), last.interpret(apply))
 
         }
     }
@@ -148,13 +148,13 @@ trait IntoPolyLower3 extends IntoPolyLower4 {
             pure(a).addLast(last.interpret(apply))
 
           case Impure(u, c, l) =>
-            Impure[FxAppend[Fx1[T], R], u.X, A](UnionAppendR(u), Arrs.singleton(x => apply(c(x))), l.interpret(apply))
+            Impure[FxAppend[Fx1[T], R], u.X, A](UnionAppendR(u), c.interpretEff(apply)(apply), l.interpret(apply))
 
           case ImpureAp(unions, continuation, l) =>
             ImpureAp[FxAppend[Fx1[T], R], unions.X, A](
               unions.into(new UnionInto[R, FxAppend[Fx1[T], R]] {
                 def apply[X](union: Union[R, X]) = UnionAppendR(union)
-              }), Arrs.singleton(x => apply(continuation(x))), l.interpret(apply))
+              }), continuation.interpretEff(apply)(apply), l.interpret(apply))
         }
     }
 }
@@ -173,8 +173,8 @@ trait IntoPolyLower4 extends IntoPolyLower5 {
 
           case Impure(u, c, l) =>
             t.project(u) match {
-              case Right(tx) => Impure[U, u.X, A](m.inject(tx), Arrs.singleton(x => apply(c(x))), l.interpret(apply))
-              case Left(s)   => recurse(Impure[S, s.X, s.X](s, Arrs.singleton(x => pure(x)))).flatMap((x: Any) => apply(c(x))).addLast(l.interpret(apply))
+              case Right(tx) => Impure[U, u.X, A](m.inject(tx), c.interpretEff(apply)(apply), l.interpret(apply))
+              case Left(s)   => recurse(Impure[S, s.X, s.X](s, Arrs.unit)).flatMap((x: Any) => apply(c(x))).addLast(l.interpret(apply))
             }
 
           case ImpureAp(unions, continuation, l) =>
@@ -183,12 +183,12 @@ trait IntoPolyLower4 extends IntoPolyLower5 {
                 t.project(u) match {
                   case Right(t1)   => m.inject(t1)
                   case Left(other) =>
-                    recurse(Impure[S, X, X](other, Arrs.singleton(x => pure(x)))) match {
+                    recurse(Impure[S, X, X](other, Arrs.unit)) match {
                       case Impure(u1, _, _) => u1.asInstanceOf[Union[U, X]]
                       case _ => sys.error("impossible into case: Impure must be transformed to Impure")
                     }
                 }
-            }), Arrs.singleton(x => apply(continuation(x))), l.interpret(apply))
+            }), continuation.interpretEff(apply)(apply), l.interpret(apply))
         }
     }
 
@@ -201,11 +201,11 @@ trait IntoPolyLower5 {
       e match {
         case Pure(a, last) => pure(a).addLast(last.interpret(apply))
         case Impure(u, c, l) =>
-          Impure(m.accept(u), Arrs.singleton((x: u.X) => apply(c(x))), l.interpret(apply))
+          Impure(m.accept(u), c.interpretEff(apply)(apply), l.interpret(apply))
 
         case ImpureAp(unions, c, l) =>
           ImpureAp(unions.into(new UnionInto[U, R] { def apply[X](u: Union[U, X]) = m.accept(u) }),
-            Arrs.singleton((xs: Vector[Any]) => apply(c(xs))), l.interpret(apply))
+            c.interpretEff(apply)(apply), l.interpret(apply))
       }
   }
 }

--- a/shared/src/main/scala/org/atnos/eff/Last.scala
+++ b/shared/src/main/scala/org/atnos/eff/Last.scala
@@ -11,8 +11,11 @@ import scala.util.control.NonFatal
 case class Last[R](value: Option[Eval[Eff[R, Unit]]]) {
 
   /** interpret this last action as a set of effects in another stack */
-  def interpret[U](n: Eff[R, Unit] => Eff[U, Unit]) =
+  def interpret[U](n: Eff[R, Unit] => Eff[U, Unit]): Last[U] =
     Last[U](value.map(v => v.map(n)))
+
+  def interpretEff[U](n: Last[R] => Eff[U, Unit]): Last[U] =
+    Last.eff(n(this))
 
   def <*(last: Last[R]): Last[R] =
     (value, last.value) match {

--- a/shared/src/main/scala/org/atnos/eff/SubscribeEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/SubscribeEffect.scala
@@ -103,14 +103,14 @@ object SubscribeEffect {
         Pure(a, last)
 
       case Impure(u, c, last) =>
-        Impure(materialize(u), Arrs.singleton((x: u.X) => memoizeSubsequence(key, sequenceKey, sub, cache, c(x))), last)
+        Impure(materialize(u), c.mapLast(r => memoizeSubsequence(key, sequenceKey, sub, cache, r)), last)
 
       case ImpureAp(unions, continuation, last) =>
 
         val materializedUnions =
           Unions(materialize(unions.first), unions.rest.map(materialize))
 
-        val continuation1 = Arrs.singleton[FS, Vector[Any], A]((ls: Vector[Any]) => memoizeSubsequence(key, sequenceKey, sub, cache, continuation(ls)))
+        val continuation1 = continuation.mapLast(r => memoizeSubsequence(key, sequenceKey, sub, cache, r))
         ImpureAp(materializedUnions, continuation1, last)
     }
   }

--- a/shared/src/main/scala/org/atnos/eff/Unions.scala
+++ b/shared/src/main/scala/org/atnos/eff/Unions.scala
@@ -24,12 +24,15 @@ case class Unions[R, A](first: Union[R, A], rest: Vector[Union[R, Any]]) {
    * if the first effect of this Unions object is interpreted
    */
   def continueWith[B](continuation: Arrs[R, Vector[Any], B]): Arrs[R, A, B] =
-  Arrs.singleton { (x: X) =>
-    rest match {
-      case v if v.isEmpty => continuation(x +: Vector.empty)
-      case h +: t         => ImpureAp[R, h.X, B](Unions[R, h.X](h, t), Arrs.singleton((ys: Vector[Any]) => continuation(x +: ys)))
-    }
-  }
+    Arrs.singleton({ x: X =>
+      rest match {
+        case v if v.isEmpty =>
+          continuation(x +: Vector.empty)
+
+        case h +: t =>
+          ImpureAp[R, h.X, B](Unions[R, h.X](h, t), continuation.contramap(x +: _))
+      }
+    }, continuation.onNone)
 
   def into[S](f: UnionInto[R, S]): Unions[S, A] =
     Unions[S, A](f(first), rest.map(f.apply))
@@ -39,17 +42,17 @@ case class Unions[R, A](first: Union[R, A], rest: Vector[Union[R, Any]]) {
    * in a stack containing no more M effects
    */
   def project[M[_], U](implicit m: Member.Aux[M, R, U]): CollectedUnions[M, R, U] =
-  collect[M, U](m.project)
+    collect[M, U](m.project)
 
   /**
    * collect all the M effects and create a continuation for other effects
    * in the same stack
    */
   def extract[M[_]](implicit m: M /= R): CollectedUnions[M, R, R] =
-  collect[M, R](u => m.extract(u) match {
-    case Some(mx) => Right(mx)
-    case None     => Left(u)
-  })
+    collect[M, R](u => m.extract(u) match {
+      case Some(mx) => Right(mx)
+      case None     => Left(u)
+    })
 
   private def collect[M[_], U](collect: Union[R, Any] => Union[U, Any] Either M[Any]): CollectedUnions[M, R, U] = {
     val (effectsAndIndices, othersAndIndices) =
@@ -84,22 +87,34 @@ object Unions {
  *
  */
 case class CollectedUnions[M[_], R, U](effects: Vector[M[Any]], otherEffects: Vector[Union[U, Any]], indices: Vector[Int], otherIndices: Vector[Int]) {
-  def continuation[A](continueWith: Vector[Any] => Eff[R, A], m: Member.Aux[M, R, U]): Arrs[R, Vector[Any], A] =
+
+  def continuation[A](continueWith: Arrs[R, Vector[Any], A], m: Member.Aux[M, R, U]): Arrs[R, Vector[Any], A] =
     otherEffects match {
-      case v if v.isEmpty => Arrs.singleton[R, Vector[Any], A](ls => continueWith(ls))
-      case o +: rest      => Arrs.singleton[R, Vector[Any], A](ls => ImpureAp[R, Any, A](Unions(m.accept(o), rest.map(m.accept)), Arrs.singleton(xs => continueWith(reorder(ls, xs)))))
+      case v if v.isEmpty =>
+        continueWith
+
+      case o +: rest =>
+        Arrs.singleton[R, Vector[Any], A](ls =>
+          ImpureAp[R, Any, A](Unions(m.accept(o), rest.map(m.accept)), continueWith.contramap(reorder(ls, _))), continueWith.onNone)
     }
 
   def continuation[A](continueWith: Arrs[U, Vector[Any], A]): Arrs[U, Vector[Any], A] =
     otherEffects match {
-      case v if v.isEmpty => continueWith
-      case o +: rest      => Arrs.singleton[U, Vector[Any], A](ls => ImpureAp[U, Any, A](Unions(o, rest), Arrs.singleton(xs => continueWith(reorder(ls, xs)))))
+      case v if v.isEmpty =>
+        continueWith
+
+      case o +: rest =>
+        Arrs.singleton[U, Vector[Any], A](ls =>
+          ImpureAp[U, Any, A](Unions(o, rest), continueWith.contramap(reorder(ls, _)), continueWith.onNone))
     }
 
   def othersEff[A](continueWith: Arrs[U, Vector[Any], A]): Eff[U, A] =
     otherEffects match {
-      case v if v.isEmpty => continueWith(Vector.empty)
-      case o +: rest      => ImpureAp[U, Any, A](Unions(o, rest), Arrs.singleton(ls => continueWith(ls)))
+      case v if v.isEmpty =>
+        continueWith(Vector.empty)
+
+      case o +: rest =>
+        ImpureAp[U, Any, A](Unions(o, rest), continueWith)
     }
 
   private def reorder(ls: Vector[Any], xs: Vector[Any]): Vector[Any] =


### PR DESCRIPTION
This is used to allow the `finally` interceptors in the Safe effect to be executed even if an other effect short-circuits all computations (see the `bracket` test cases in the `SafeEffectSpec`).

I have also added a `bracketLast` method to `Eff`. The main difference with `SafeEffect.bracket` are:
 - that the "last" action is always executed at the end of the program whether or not the protected Eff computation has additional flatMaps or not

 - no finalizer exception is reported with the "last" action

**Implementation**

The `Arrs` class gets an additional `onNone` parameter representing an action to execute when there is no value available to feed the continuation. This is the case when the `Safe` effect wants to protect computations and clean-up resources but an additional `Either` effect stops all computations with a `Left` value. This issue happened on the [eff gitter channel](https://gitter.im/atnos-org/eff?at=58a175ee00c00c3d4f301675) first.

@edmundnoble this is a massive PR where most of the work is in making sure that the `onNone` action doesn't get lost. There's probably a missing `Profunctor` instance lost for `Arrs` but it's a bit too late for me to fix this :-).