### PR TITLE
Fix State.modify for applicative case

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/StateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/StateEffectSpec.scala
@@ -11,6 +11,7 @@ class StateEffectSpec extends Specification with ScalaCheck { def is = s2"""
 
  The state monad can be used to put/get state $putGetState
  modify can be used to modify the current state $modifyState
+ The state monad works applicatively $applicativeState
 
  A State[T, ?] effect can be lifted into a State[S, ?] effect
    provided there is a "lens" (a getter and a setter) from T to S $lensedState
@@ -52,6 +53,15 @@ class StateEffectSpec extends Specification with ScalaCheck { def is = s2"""
 
     action.runState(0).run ==== ((list.map(_.toString), 5000))
   }
+
+  def applicativeState = {
+
+    val stateAction = StateEffect.modify[SI, Int](_ + 1)
+
+    (stateAction *> stateAction).runState(0).run ====
+      (stateAction >> stateAction).runState(0).run
+  }
+
 
   def lensedState = {
     type StateIntPair[A] = State[(Int, Int), A]

--- a/shared/src/main/scala/org/atnos/eff/StateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/StateEffect.scala
@@ -34,7 +34,7 @@ trait StateCreation {
 
   /** modify the current state value */
   def modify[R, S](f: S => S)(implicit member: State[S, ?] |= R): Eff[R, Unit] =
-    get >>= ((s: S) => put(f(s)))
+    send[State[S, ?], R, Unit](State.modify(f))
 
 }
 


### PR DESCRIPTION
Amazingly, State.modify does not work properly if used applicatively. All of the state updates get run one after the other, but they don't get the results of the previous one.