### PR TITLE
 Replace ScheduledExecutorService in async effects with Timer for JS compat

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/FutureEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/FutureEffectSpec.scala
@@ -1,5 +1,9 @@
 package org.atnos.eff
 
+import java.util.concurrent.{Callable, TimeUnit}
+import java.util.{Date, Timer, TimerTask}
+
+import cats.Eval
 import cats.implicits._
 import org.atnos.eff.all._
 import org.atnos.eff.future._
@@ -11,7 +15,6 @@ import org.specs2.concurrent.ExecutionEnv
 import scala.collection.mutable.ListBuffer
 import scala.concurrent._
 import duration._
-
 import org.specs2.matcher.ThrownExpectations
 
 import scala.util.control._
@@ -37,7 +40,7 @@ class FutureEffectSpec(implicit ee: ExecutionEnv) extends Specification with Sca
 
   type S = Fx.fx2[TimedFuture, Option]
 
-  implicit val ses = ee.ses
+  implicit val timer = ExecutorServices.timerFromScheduledExecutorService(ee.ses)
   implicit val ec = ee.ec
 
   def e1 = {

--- a/jvm/src/test/scala/org/atnos/site/ApplicativeEvaluation.scala
+++ b/jvm/src/test/scala/org/atnos/site/ApplicativeEvaluation.scala
@@ -1,6 +1,6 @@
 package org.atnos.site
 
-import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.Timer
 
 import scala.annotation.tailrec
 
@@ -24,7 +24,7 @@ type _writerString[R] = WriterString |= R
 
 type S = Fx.fx3[Eval, TimedFuture, WriterString]
 
-implicit val ses = new ScheduledThreadPoolExecutor(Runtime.getRuntime.availableProcessors())
+implicit val timer = new Timer()
 
 def execute[E :_eval :_writerString :_future](i: Int): Eff[E, Int] =
   for {
@@ -53,7 +53,7 @@ type WriterString[A] = Writer[String, A]
 type _writerString[R] = WriterString |= R
 
 type S = Fx.fx3[Eval, TimedFuture, WriterString]
-val ses = new ScheduledThreadPoolExecutor(Runtime.getRuntime.availableProcessors())
+implicit val timer = new Timer()
 
 def execute[E :_eval :_writerString :_future](i: Int): Eff[E, Int] =
   for {
@@ -66,8 +66,7 @@ def execute[E :_eval :_writerString :_future](i: Int): Eff[E, Int] =
 val action: Eff[S, List[Int]] =
   List(1000, 500, 50).traverseA(execute[S])
 
-Await.result(Eff.detachA(action.runEval.runWriterLog[String])(TimedFuture.MonadTimedFuture, TimedFuture.ApplicativeTimedFuture).runNow(ses, global
-), 2.seconds)
+Await.result(Eff.detachA(action.runEval.runWriterLog[String])(TimedFuture.MonadTimedFuture, TimedFuture.ApplicativeTimedFuture).runNow(timer, global), 2.seconds)
 }.eval}
 
 This uses now `traverseA` (instead of `traverse`) to do an applicative traversal and execute futures concurrently and

--- a/jvm/src/test/scala/org/atnos/site/OutOfTheBox.scala
+++ b/jvm/src/test/scala/org/atnos/site/OutOfTheBox.scala
@@ -378,6 +378,7 @@ import org.atnos.eff.future._
 import org.atnos.eff.syntax.all._
 
 import scala.concurrent._, duration._
+import java.util.Timer
 import scala.concurrent.ExecutionContext.Implicits.global
 
 type R = Fx.fx2[TimedFuture, Option]
@@ -392,10 +393,10 @@ val action: Eff[R, Int] =
   } yield b
 
 /*p
-Then we need to pass a `ScheduledExecutorService` and `ExecutionContext` in to begin the computation.
+Then we need to pass a `Timer` and `ExecutionContext` in to begin the computation.
 */
 
-implicit val ses = new ScheduledThreadPoolExecutor(Runtime.getRuntime.availableProcessors())
+implicit val timer = new Timer()
 import org.atnos.eff.syntax.future._
 
 Await.result(action.runOption.runSequential, 1 second)
@@ -427,6 +428,7 @@ import org.atnos.eff._, future._, all._
 import org.atnos.eff.syntax.all._
 import org.atnos.eff.syntax.future._
 import scala.concurrent._, duration._
+import java.util.Timer
 import scala.concurrent.ExecutionContext.Implicits.global
 
 var i = 0
@@ -436,7 +438,7 @@ def expensive[R :_Future :_memo]: Eff[R, Int] =
 
 type S = Fx.fx2[Memoized, TimedFuture]
 
-implicit val ses = new ScheduledThreadPoolExecutor(Runtime.getRuntime.availableProcessors())
+implicit val timer = new Timer()
 
 val futureMemo: Future[Int] =
   (expensive[S] >> expensive[S]).runFutureMemo(ConcurrentHashMapCache()).runSequential

--- a/monix/jvm/src/test/scala/org/atnos/eff/addon/monix/TaskEffectSpec.scala
+++ b/monix/jvm/src/test/scala/org/atnos/eff/addon/monix/TaskEffectSpec.scala
@@ -33,7 +33,7 @@ class TaskEffectSpec(implicit ee: ExecutionEnv) extends Specification with Scala
 
   type S = Fx.fx2[TimedTask, Option]
 
-  implicit val ses = ee.ses
+  implicit val timer = ExecutorServices.timerFromScheduledExecutorService(ee.ses)
 
   def e1 = {
     def action[R :_task :_option]: Eff[R, Int] = for {

--- a/monix/shared/src/main/scala/org/atnos/eff/syntax/addon/monix/task.scala
+++ b/monix/shared/src/main/scala/org/atnos/eff/syntax/addon/monix/task.scala
@@ -1,6 +1,6 @@
 package org.atnos.eff.syntax.addon.monix
 
-import java.util.concurrent.ScheduledExecutorService
+import java.util.Timer
 
 import org.atnos.eff.{Fx, _}
 import org.atnos.eff.addon.monix._
@@ -24,10 +24,10 @@ final class TaskOps[R, A](val e: Eff[R, A]) extends AnyVal {
   def taskMemo(key: AnyRef, cache: Cache)(implicit task: TimedTask /= R): Eff[R, A] =
     TaskInterpretation.taskMemo(key, cache, e)
 
-  def runAsync(implicit sexs: ScheduledExecutorService, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
+  def runAsync(implicit timer: Timer, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
     TaskInterpretation.runAsync(e)
 
-  def runSequential(implicit sexs: ScheduledExecutorService, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
+  def runSequential(implicit timer: Timer, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
     TaskInterpretation.runSequential(e)
 }
 

--- a/scalaz/src/main/scala/org/atnos/eff/syntax/addon/scalaz/task.scala
+++ b/scalaz/src/main/scala/org/atnos/eff/syntax/addon/scalaz/task.scala
@@ -1,6 +1,6 @@
 package org.atnos.eff.syntax.addon.scalaz
 
-import java.util.concurrent.ScheduledExecutorService
+import java.util.Timer
 
 import org.atnos.eff.addon.scalaz.concurrent.{TaskEffect, TaskInterpretation, TimedTask}
 import org.atnos.eff.{Fx, _}
@@ -29,9 +29,9 @@ final class TaskOps[R, A](val e: Eff[R, A]) extends AnyVal {
   def taskMemo(key: AnyRef, cache: Cache)(implicit async: TimedTask /= R): Eff[R, A] =
     TaskInterpretation.taskMemo(key, cache, e)
 
-  def runAsync(implicit sexs: ScheduledExecutorService, ec: ExecutionContext, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
+  def runAsync(implicit timer: Timer, ec: ExecutionContext, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
     TaskInterpretation.runAsync(e)
 
-  def runSequential(implicit sexs: ScheduledExecutorService, ec: ExecutionContext, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
+  def runSequential(implicit timer: Timer, ec: ExecutionContext, m: Member.Aux[TimedTask, R, NoFx]): Task[A] =
     TaskInterpretation.runSequential(e)
 }

--- a/scalaz/src/test/scala/org/atnos/eff/addon/scalaz/concurrent/TaskEffectSpec.scala
+++ b/scalaz/src/test/scala/org/atnos/eff/addon/scalaz/concurrent/TaskEffectSpec.scala
@@ -33,7 +33,7 @@ class TaskEffectSpec(implicit ee: ExecutionEnv) extends Specification with Scala
 
   type S = Fx.fx2[TimedTask, Option]
 
-  implicit val ses = ee.ses
+  implicit val timer = ExecutorServices.timerFromScheduledExecutorService(ee.ses)
   implicit val ec = ee.ec
 
   def e1 = {

--- a/shared/src/main/scala/org/atnos/eff/ExecutorServices.scala
+++ b/shared/src/main/scala/org/atnos/eff/ExecutorServices.scala
@@ -1,6 +1,6 @@
 package org.atnos.eff
 
-import java.util.Collections
+import java.util.{Collections, Date, Timer, TimerTask}
 import java.util.concurrent._
 
 import cats.Eval
@@ -90,6 +90,50 @@ object ExecutorServices {
         override def awaitTermination(length: Long, unit: TimeUnit): Boolean = false
       }
     }
+
+  def timerTaskToRunnable(timerTask: TimerTask): Runnable = new Runnable {
+    override def run(): Unit = {
+      timerTask.run()
+    }
+  }
+
+  def timerFromScheduledExecutorService(ses: ScheduledExecutorService): Timer = new Timer {
+    override def schedule(task: TimerTask, delay: Long): Unit = {
+      val _ = ses.schedule(timerTaskToRunnable(task), delay, TimeUnit.MILLISECONDS)
+    }
+
+    override def schedule(task: TimerTask, time: Date): Unit = {
+      val delay = new Date().getTime - time.getTime
+      schedule(task, delay)
+    }
+
+    override def schedule(task: TimerTask, delay: Long, period: Long): Unit = {
+      val _ = ses.scheduleWithFixedDelay(timerTaskToRunnable(task), delay, period, TimeUnit.MILLISECONDS)
+    }
+
+    override def schedule(task: TimerTask, firstTime: Date, period: Long): Unit = {
+      val delay = new Date().getTime - firstTime.getTime
+      schedule(task, delay, period)
+    }
+
+    override def scheduleAtFixedRate(task: TimerTask, delay: Long, period: Long): Unit = {
+      val _ = ses.scheduleAtFixedRate(timerTaskToRunnable(task), delay, period, TimeUnit.MILLISECONDS)
+    }
+
+    override def scheduleAtFixedRate(task: TimerTask, firstTime: Date,
+                                     period: Long): Unit = {
+      val delay = new Date().getTime - firstTime.getTime
+      scheduleAtFixedRate(task, delay, period)
+    }
+
+    override def cancel(): Unit = {
+    }
+
+    override def purge(): Int = {
+      0
+    }
+
+  }
 
   /** create an ExecutionEnv from Scala global execution context */
   def fromGlobalExecutionContext: ExecutorServices =

--- a/shared/src/main/scala/org/atnos/eff/syntax/future.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/future.scala
@@ -1,6 +1,6 @@
 package org.atnos.eff.syntax
 
-import java.util.concurrent.ScheduledExecutorService
+import java.util.Timer
 
 import org.atnos.eff._
 
@@ -22,10 +22,10 @@ final class FutureOps[R, A](val e: Eff[R, A]) extends AnyVal {
   def futureMemo(key: AnyRef, cache: Cache)(implicit future: TimedFuture /= R): Eff[R, A] =
     FutureInterpretation.futureMemo(key, cache, e)
 
-  def runAsync(implicit sexs: ScheduledExecutorService, exc: ExecutionContext, m: Member.Aux[TimedFuture, R, NoFx]): Future[A] =
+  def runAsync(implicit timer: Timer, exc: ExecutionContext, m: Member.Aux[TimedFuture, R, NoFx]): Future[A] =
     FutureInterpretation.runAsync(e)
 
-  def runSequential(implicit sexs: ScheduledExecutorService, exc: ExecutionContext, m: Member.Aux[TimedFuture, R, NoFx]): Future[A] =
+  def runSequential(implicit timer: Timer, exc: ExecutionContext, m: Member.Aux[TimedFuture, R, NoFx]): Future[A] =
     FutureInterpretation.runSequential(e)
 }
 

--- a/twitter/src/main/scala/org/atnos/eff/syntax/addon/twitter/future.scala
+++ b/twitter/src/main/scala/org/atnos/eff/syntax/addon/twitter/future.scala
@@ -1,6 +1,6 @@
 package org.atnos.eff.syntax.addon.twitter
 
-import java.util.concurrent.ScheduledExecutorService
+import java.util.Timer
 
 import com.twitter.util.{Future, FuturePool}
 import org.atnos.eff.addon.twitter._
@@ -26,9 +26,9 @@ final class TwitterFutureOps[R, A](val e: Eff[R, A]) extends AnyVal {
   def twitterFutureMemo(key: AnyRef, cache: Cache)(implicit future: TwitterTimedFuture /= R): Eff[R, A] =
     TwitterFutureInterpretation.futureMemo(key, cache, e)
 
-  def runAsync(implicit pool: FuturePool, sexs: ScheduledExecutorService, m: Member.Aux[TwitterTimedFuture, R, NoFx]): Future[A] =
+  def runAsync(implicit pool: FuturePool, timer: Timer, m: Member.Aux[TwitterTimedFuture, R, NoFx]): Future[A] =
     TwitterFutureInterpretation.runAsync(e)
 
-  def runSequential(implicit pool: FuturePool, sexs: ScheduledExecutorService, m: Member.Aux[TwitterTimedFuture, R, NoFx]): Future[A] =
+  def runSequential(implicit pool: FuturePool, timer: Timer, m: Member.Aux[TwitterTimedFuture, R, NoFx]): Future[A] =
     TwitterFutureInterpretation.runSequential(e)
 }

--- a/twitter/src/test/scala/org/atnos/eff/addon/twitter/TwitterFutureEffectSpec.scala
+++ b/twitter/src/test/scala/org/atnos/eff/addon/twitter/TwitterFutureEffectSpec.scala
@@ -40,7 +40,7 @@ class TwitterFutureEffectSpec(implicit ee: ExecutionEnv) extends Specification w
   type S = Fx.fx2[TwitterTimedFuture, Option]
   
   implicit val pool = FuturePool(ee.es)
-  implicit val ses = ee.ses
+  implicit val timer = ExecutorServices.timerFromScheduledExecutorService(ee.ses)
 
   def e1 = {
     def action[R :_future :_option]: Eff[R, Int] = for {


### PR DESCRIPTION
Users on JS cannot manufacture `java.util.concurrent.ScheduledExecutorService`s with which to call `runAsync` or `runSequential` because it is not included in their version of the Java stdlib. This PR thus replaces all of their occurrences with `java.util.Timer`.