### PR TITLE
Add pure union

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
@@ -29,6 +29,7 @@ class EffSpec extends Specification with ScalaCheck { def is = s2"""
  The Eff monad is stack safe with Reader                 $stacksafeReader
  The Eff monad is stack safe with both Reader and Writer $stacksafeReaderWriter
  The Eff monad is tail recursive                         $tailrec
+ The Eff monad is stack safe with pure flatMaps          $safePureFlatMaps
 
  It is possible to run a pure Eff value $runPureValue
  It is possible to run a Eff value with one effects $runOneEffect
@@ -140,6 +141,16 @@ class EffSpec extends Specification with ScalaCheck { def is = s2"""
       }
 
     action.runEval.run ==== 5000
+  }
+
+  def safePureFlatMaps = {
+    type S = Fx.fx1[Eval]
+
+    def action(e: Eff[S, Int], i: Int = 0): Eff[S, Int] =
+      if (i == 5000) e
+      else action(e.flatMap(j => pure[S, Int](j + 1)), i + 1)
+
+    action(Eff.pure[S, Int](0)).runEval.run ==== 5000
   }
 
   def runPureValue =

--- a/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
@@ -28,6 +28,7 @@ class EffSpec extends Specification with ScalaCheck { def is = s2"""
  The Eff monad is stack safe with Writer                 $stacksafeWriter
  The Eff monad is stack safe with Reader                 $stacksafeReader
  The Eff monad is stack safe with both Reader and Writer $stacksafeReaderWriter
+ The Eff monad is tail recursive                         $tailrec
 
  It is possible to run a pure Eff value $runPureValue
  It is possible to run a Eff value with one effects $runOneEffect
@@ -127,6 +128,18 @@ class EffSpec extends Specification with ScalaCheck { def is = s2"""
     val action = list.traverse(i => ReaderEffect.ask[S, String] >>= WriterEffect.tell[S, String])
 
     action.runReader("h").runWriter.run ==== ((list.as(()), list.as("h")))
+  }
+
+  def tailrec = {
+    type S = Fx.fx1[Eval]
+
+    val action: Eff[S, Int] =
+      EffMonad[S].tailRecM(1) { i =>
+        if (i >= 5000) Pure(Right(i))
+        else Pure(Left(i + 1))
+      }
+
+    action.runEval.run ==== 5000
   }
 
   def runPureValue =

--- a/jvm/src/test/scala/org/atnos/eff/IntoPolySpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/IntoPolySpec.scala
@@ -87,7 +87,8 @@ class IntoPolySpec extends Specification with ThrownExpectations { def is = s2""
   def runOption[T[_] <: OptionLike[_], R, U](e: Eff[R, Int])(implicit m: Member.Aux[T, R, U]): Eff[U, Int] =
     e match {
       case Pure(a, _) => Eff.pure(a)
-      case Impure(u, c, _) =>
+      case Impure(NoEffect(a), c, _) => runOption(c(a))
+      case Impure(u: Union[_,_], c, _) =>
         m.project(u) match {
           case Right(oa) => runOption(c(oa.a))
           case Left(u1) => Impure[U, u1.X, Int](u1, Arrs.singleton(x => runOption(c(x))))

--- a/scalaz/src/main/scala/org/atnos/eff/addon/scalaz/package.scala
+++ b/scalaz/src/main/scala/org/atnos/eff/addon/scalaz/package.scala
@@ -64,8 +64,12 @@ package object scalaz {
         case Pure(a, Last(Some(l))) => Monad[M].point(-\/(l.value.as(a)))
         case Pure(a, Last(None))    => Monad[M].point(\/-(a))
 
+        case Impure(NoEffect(a), continuation, last) =>
+          Monad[M].point(-\/(continuation(a).addLast(last)))
+
         case Impure(u, continuation, last) =>
           u match {
+            case NoEffect(a) => Monad[M].point(-\/(continuation(a).addLast(last)))
             case UnionTagged(ta: M[Nothing] @unchecked, _) =>
               last match {
                 case Last(Some(l)) => Monad[M].map(ta)(x => -\/(continuation(x).addLast(last)))
@@ -82,8 +86,12 @@ package object scalaz {
         case Pure(a, Last(Some(l))) => monad.point(-\/(l.value.as(a)))
         case Pure(a, Last(None))    => monad.point(\/-(a))
 
+        case Impure(NoEffect(a), continuation, last) =>
+          monad.point(-\/(continuation(a).addLast(last)))
+
         case Impure(u, continuation, last) =>
           u match {
+            case NoEffect(a) => Monad[M].point(-\/(continuation(a).addLast(last)))
             case UnionTagged(ta: M[Nothing] @unchecked, _) =>
               last match {
                 case Last(Some(l)) => Monad[M].map(ta)(x => -\/(continuation(x).addLast(last)))

--- a/shared/src/main/scala/org/atnos/eff/Choose.scala
+++ b/shared/src/main/scala/org/atnos/eff/Choose.scala
@@ -79,7 +79,10 @@ trait ChooseInterpretation {
             case Pure(a, last) =>
               go(rest, (EffMonad[U].pure(alternativeF.pure(a)) |@| result).map(alternativeF.combineK), resultLast.map(_ <* lastRun(last)))
 
-            case Impure(u, c, last) =>
+            case Impure(NoEffect(a), c, last) =>
+              runChoose(c(a).addLast(last))
+              
+            case Impure(u: Union[_, _], c, last) =>
               m.project(u) match {
                 case Left(u1) =>
                   val r1 = Impure(u1, c.interpret(runChoose[R, U, A, F])(_.interpret(l => runChoose[R, U, Unit, F](l).void))).addLast(lastRun(last))

--- a/shared/src/main/scala/org/atnos/eff/Fx.scala
+++ b/shared/src/main/scala/org/atnos/eff/Fx.scala
@@ -1,8 +1,5 @@
 package org.atnos.eff
 
-/** one effect, basically a type constructor */
-sealed trait Effect[+F[_]]
-
 /**
  * Base type for a tree of effect types
  */
@@ -39,11 +36,11 @@ object Fx {
 /**
  * Append a tree of effects to another one
  */
-final case class FxAppend[+L, +R](left: L, right: R) extends Fx
+trait FxAppend[+L, +R] extends Fx
 
-final case class Fx1[+F[_]](e: Effect[F]) extends Fx
-final case class Fx2[+L[_], +R[_]](left: Effect[L], right: Effect[R]) extends Fx
-final case class Fx3[+L[_], +M[_], +R[_]](left: Effect[L], middle: Effect[M], right: Effect[R]) extends Fx
+trait Fx1[+F[_]] extends Fx
+trait Fx2[+L[_], +R[_]] extends Fx
+trait Fx3[+L[_], +M[_], +R[_]] extends Fx
 
 /**
  * The "empty" tree of effects

--- a/shared/src/main/scala/org/atnos/eff/Member.scala
+++ b/shared/src/main/scala/org/atnos/eff/Member.scala
@@ -260,7 +260,7 @@ trait MemberLower4 extends MemberLower5 {
       union match {
         case UnionAppendL(l) => Right(l.tagged.valueUnsafe.asInstanceOf[T[V]])
         case UnionAppendR(r) => Left(r)
-        case _ => sys.error("impossible")
+        case _               => sys.error("impossible")
       }
   }
 }
@@ -280,7 +280,7 @@ trait MemberLower5 extends MemberLower6 {
 
     def project[V](union: Union[FxAppend[Fx1[T], Fx3[L, M, R]], V]): Union[Fx3[T, M, R], V] Either L[V] =
       union match {
-        case UnionAppendL(l) => Left(l.tagged.forget)
+        case UnionAppendL(l) => Left(l.forget)
         case UnionAppendR(r) =>
           val tagged = r.tagged
           (tagged.index: @switch) match {
@@ -309,7 +309,7 @@ trait MemberLower6 extends MemberLower7 {
     }
 
     def project[V](union: Union[FxAppend[Fx1[T], Fx3[L, M, R]], V]): Union[Fx3[T, L, R], V] Either M[V] = union match {
-      case UnionAppendL(l) => Left(l.tagged.forget)
+      case UnionAppendL(l) => Left(l.forget)
       case UnionAppendR(r) =>
         val tagged = r.tagged
         (tagged.index: @switch) match {
@@ -336,7 +336,7 @@ trait MemberLower7 extends MemberLower8 {
     }
 
     def project[V](union: Union[FxAppend[Fx1[T], Fx3[L, M, R]], V]): Union[Fx3[T, L, M], V] Either R[V] = union match {
-      case UnionAppendL(l) => Left(l.tagged.forget)
+      case UnionAppendL(l) => Left(l.forget)
       case UnionAppendR(r) =>
         val tagged = r.tagged
         if (tagged.index == 3) Right(tagged.valueUnsafe.asInstanceOf[R[V]])
@@ -354,8 +354,8 @@ trait MemberLower8 extends MemberLower9 {
       Union.appendL(Union.one(e))
 
     def project[V](union: Union[FxAppend[Fx1[T], R], V]): Union[Out, V] Either T[V] = union match {
-      case UnionAppendR(r) => Left(r)
-      case UnionAppendL(l) => Right(l.tagged.valueUnsafe.asInstanceOf[T[V]])
+      case UnionAppendR(r)   => Left(r)
+      case UnionAppendL(l)   => Right(l.tagged.valueUnsafe.asInstanceOf[T[V]])
       case UnionTagged(_, _) => sys.error("impossible")
     }
 
@@ -402,8 +402,8 @@ trait MemberLower14 extends MemberLower15 {
     }
 
     def project[V](union: Union[FxAppend[L, R], V]): Union[Out, V] Either T[V] = union match {
-      case UnionAppendL(r) => append.project(r).left.map(Union.appendL)
-      case UnionAppendR(_) => Left(union.forget)
+      case UnionAppendL(r)   => append.project(r).left.map(Union.appendL)
+      case UnionAppendR(_)   => Left(union.forget)
       case UnionTagged(_, _) => sys.error("impossible")
     }
   }
@@ -466,15 +466,15 @@ trait MemberLower17 extends MemberLower18 {
 
     def accept[V](union: Union[Out, V]): Union[FxAppend[L, R], V] =
       union match {
-        case UnionAppendL(u) => UnionAppendL(u)
-        case UnionAppendR(u) => UnionAppendR(append.accept(u))
+        case UnionAppendL(u)   => UnionAppendL(u)
+        case UnionAppendR(u)   => UnionAppendR(append.accept(u))
         case UnionTagged(_, _) => sys.error("impossible")
       }
 
     def project[V](union: Union[FxAppend[L, R], V]): Union[Out, V] Either T[V] =
       union match {
-        case UnionAppendL(u) => Left(UnionAppendL(u))
-        case UnionAppendR(u) => append.project(u).leftMap(UnionAppendR.apply)
+        case UnionAppendL(u)   => Left(UnionAppendL(u))
+        case UnionAppendR(u)   => append.project(u).leftMap(UnionAppendR.apply)
         case UnionTagged(_, _) => sys.error("impossible")
       }
 
@@ -489,7 +489,7 @@ trait MemberLower18 extends MemberLower19 {
       Union.threeR(tv)
 
     def accept[V](union: Union[Out, V]): Union[Fx3[L, M, R], V] =
-      union.tagged.forget
+      union.forget
 
     def project[V](union: Union[Fx3[L, M, R], V]): Union[Out, V] Either R[V] = union match {
       case tagged@UnionTagged(value, index) =>

--- a/shared/src/main/scala/org/atnos/eff/SubscribeEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/SubscribeEffect.scala
@@ -100,7 +100,10 @@ object SubscribeEffect {
       case Pure(a, last) =>
         Pure(a, last)
 
-      case Impure(u, c, last) =>
+      case Impure(NoEffect(a), c, last) =>
+        memoizeSubsequence(key, sequenceKey, subSequenceKey, cache, c(a).addLast(last))
+
+      case Impure(u: Union[_,_], c, last) =>
         Impure(materialize(u), c.mapLast(r => memoizeSubsequence(key, sequenceKey, sub, cache, r)), last)
 
       case ImpureAp(unions, continuation, last) =>

--- a/shared/src/main/scala/org/atnos/eff/Union.scala
+++ b/shared/src/main/scala/org/atnos/eff/Union.scala
@@ -16,14 +16,20 @@ package org.atnos.eff
  *  In that respect UnionTagged behaves similarly to a tagged union in C or C++.
  *
  */
-sealed trait Union[R, A] {
+sealed trait Effect[R, A] {
   type X = A
+}
+
+case class NoEffect[R, A](a: A) extends Effect[R, A]
+
+sealed trait Union[R, A] extends Effect[R, A]  {
   final private[eff] def forget[E, B]: Union[E, B] =
     asInstanceOf[Union[E, B]]
 
   final private[eff] def tagged: UnionTagged[R, A] =
     this.asInstanceOf[UnionTagged[R, A]]
 }
+
 case class UnionTagged[R, A] (valueUnsafe: Any, index: Int) extends Union[R, A] {
   private[eff] def increment[E]: Union[E, A] = copy(index = index + 1)
   private[eff] def decrement[E]: Union[E, A] = copy(index = index - 1)

--- a/shared/src/main/scala/org/atnos/eff/Unions.scala
+++ b/shared/src/main/scala/org/atnos/eff/Unions.scala
@@ -135,7 +135,10 @@ trait UnionInto[R, S] {
       case Pure(a, last) =>
         Eff.pure(a).addLast(last.interpret(into))
 
-      case Impure(u, c, l) =>
+      case Impure(NoEffect(a), c, l) =>
+        into(c(a).addLast(l))
+
+      case Impure(u: Union[_, _], c, l) =>
         Impure(apply(u), c.interpretEff(into)(into), l.interpret(into))
 
       case ImpureAp(unions, continuation, last) =>


### PR DESCRIPTION
@edmundnoble please have a look at this PR. It started from a use case at work where we had a SOE with a large chain of flatMaps just using `pure`. 

In this PR I introduce the possibility to have a pure value in the `Impure` case, denoted as `NoEffect(a)` instead of the usual `Union` of effects. 

So now we have:
```
sealed trait Effect[R, A]
case class NoEffect[R, A](a: A) extends Effect[R, A]
sealed trait Union[R, A] extends Effect[R, A]
```

This lets me use a continuation even on pure values, and avoid the issue with flatMaps on pure values.

More importantly I think this opens the possibility to write a generic interpreter like `handle_relay` in the original paper. I wrote a small prototype for the `Writer` effect and it works. This could greatly simplify the `Interpret` trait (at the expense of me rewriting lots of stuff...)