### PR TITLE
Generate boilerplate using macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 target/
 .settings
+/.ensime*

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ lazy val eff = project.in(file("."))
   .settings(moduleName := "root")
   .settings(effSettings)
   .settings(noPublishSettings)
-  .aggregate(coreJVM, coreJS, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
-  .dependsOn(coreJVM, coreJS, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
+  .aggregate(coreJVM, coreJS, macros, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
+  .dependsOn(coreJVM, coreJS, macros, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
 
 lazy val core = crossProject.crossType(CrossType.Full).in(file("."))
   .settings(moduleName := "eff")
@@ -24,6 +24,14 @@ lazy val core = crossProject.crossType(CrossType.Full).in(file("."))
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
+
+lazy val macros = project.in(file("macros"))
+  .settings(moduleName := "eff-macros")
+  .dependsOn(coreJVM)
+  .settings(libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value)
+  .settings(addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full))
+  .settings(commonJvmSettings)
+  .settings(effSettings:_*)
 
 lazy val monix = crossProject.crossType(CrossType.Full).in(file("monix"))
   .settings(moduleName := "eff-monix")

--- a/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
+++ b/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
@@ -166,7 +166,7 @@ class EffMacros(val c: blackbox.Context) {
                       cq"${adt(name)} => $name"
                   }}
                 }
-                def applicative[X, Tr[_] : Traverse](ms: Tr[${sealedTrait.name}[X]]): Tr[X] =
+                def applicative[X, Tr[_] : cats.Traverse](ms: Tr[${sealedTrait.name}[X]]): Tr[X] =
                   ms.map(apply)
                 def run[R, A](effects: Eff[R, A])(implicit m: ${sealedTrait.name} <= R): Eff[m.Out, A] =
                   org.atnos.eff.interpret.interpretUnsafe(effects)(this)(m)

--- a/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
+++ b/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
@@ -166,8 +166,8 @@ class EffMacros(val c: blackbox.Context) {
                       cq"${adt(name)} => $name"
                   }}
                 }
-                def applicative[X, Tr[_] : cats.Traverse](ms: Tr[${sealedTrait.name}[X]]): Tr[X] =
-                  ms.map(apply)
+                def applicative[X, Tr[_]](ms: Tr[${sealedTrait.name}[X]])(implicit traverse: cats.Traverse[Tr]): Tr[X] =
+                  traverse.map(ms)(apply)
                 def run[R, A](effects: Eff[R, A])(implicit m: ${sealedTrait.name} <= R): Eff[m.Out, A] =
                   org.atnos.eff.interpret.interpretUnsafe(effects)(this)(m)
                 ..$methodsToBeImpl

--- a/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
+++ b/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
@@ -275,6 +275,8 @@ class EffMacros(val c: blackbox.Context) {
         val genTrait =
           q"""
             trait ${tpname.toTypeName} { $self =>
+              import scala.language.higherKinds
+
               ..${stats.diff(absValsDefsOps)}
               ..$genCaseClassesAndObjADT
               ..$injectOpsObj

--- a/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
+++ b/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
@@ -15,10 +15,6 @@ class eff extends StaticAnnotation {
 class EffMacros(val c: blackbox.Context) {
   import c.universe._
 
-  val imports: Tree =
-    q"""
-       import cats._
-     """
   def abort(msg: String) = c.abort(c.enclosingPosition, msg)
 
   // https://issues.scala-lang.org/browse/SI-8771
@@ -233,8 +229,6 @@ class EffMacros(val c: blackbox.Context) {
         val genCompanionObj =
           q"""
             object ${tpname.toTermName} {
-              ..$imports
-              import scala.language.higherKinds
               $sealedTrait
               $typeAlias
               $genCaseClassesAndObjADT

--- a/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
+++ b/macros/src/main/scala/org/atnos/eff/macros/EffMacros.scala
@@ -1,0 +1,212 @@
+package org.atnos.eff.macros
+
+import scala.reflect.api.Trees
+import scala.reflect.macros.blackbox
+
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+@compileTimeOnly("enable macro paradise to expand macro annotations")
+class eff extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro EffMacros.impl
+}
+
+class EffMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  val imports: Tree =
+    q"""
+       import cats._
+     """
+  def abort(msg: String) = c.abort(c.enclosingPosition, msg)
+
+  // https://issues.scala-lang.org/browse/SI-8771
+  def fixSI88771(paramss: Any) = paramss.asInstanceOf[List[List[ValDef]]].map(_.map(_.duplicate))
+
+  def replaceContainerType(tree: Trees#Tree, newType: TypeName): AppliedTypeTree = tree match {
+    case AppliedTypeTree(_, inner) => AppliedTypeTree(Ident(newType), inner)
+    case other => abort(s"Not an AppliedTypeTree: ${showRaw(other)}")
+  }
+
+  def adt(sealedTrait: ClassDef, name: Name) = q"${sealedTrait.name.toTermName}.${TermName(name.toString.capitalize)}"
+
+  type Paramss = List[List[ValDef]]
+  def paramssToArgs(paramss: Paramss): List[List[TermName]] =
+    paramss.filter(_.nonEmpty).map(_.collect { case t@ValDef(mods, name, _, _) => name })
+
+  // remove () if no args
+  def methodCallFmt(method: c.universe.Tree, args: Seq[Seq[TermName]]) = if (args.flatten.isEmpty) method else q"$method(...$args)"
+
+  def impl(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    val trees = annottees.map(_.tree).toList
+
+    trees.headOption match {
+      case Some(q"$_ trait ${tpname:TypeName}[..$_] extends { ..$earlydefns } with ..$parents { $self => ..$stats }") =>
+        val (typeAlias: TypeDef, freeSType) =
+          stats.collectFirst { case typeDef @ q"type $_[..$_] = MemberIn[${Ident(s)}, $_]" => (typeDef, s) }
+            .getOrElse(abort(s"$tpname needs to define a type alias for MemberIn[S, A]"))
+
+        val sealedTrait: ClassDef = stats.collectFirst {
+          case cd @ q"sealed trait $name[..$_]" if name == freeSType => cd.asInstanceOf[ClassDef]
+        }.getOrElse(abort(s"$tpname needs to define a sealed trait $freeSType[A]"))
+
+        case class EffType(effectType: Tree, returnTypeTree: Tree)
+        object ExpectedReturnType {
+          def unapply(rt: Tree): Option[EffType] = rt match {
+            case AppliedTypeTree(Ident(name), List(effectType, returnType))  if name.toString == "Eff" =>
+              Some(EffType(effectType, returnType))
+            case _ => None
+          }
+        }
+        def isReturnTypeOfTypeAlias(rt: Tree): Boolean = rt match {
+          case ExpectedReturnType(_) => true
+          case _ => false
+        }
+
+        // check some constraints that will result in a compiler error
+        stats.foreach {
+          case x:ValOrDefDef if x.mods.hasFlag(Flag.PRIVATE|Flag.PROTECTED) => c.abort(x.pos, "try using access modifier: package-private")
+          case v @ ValDef(_, _, rt: TypeTree, _)       => c.abort(v.pos, s"Define the return type for:") // requires explicit return type
+          case d @ DefDef(_, _, _, _, rt: TypeTree, _) => c.abort(d.pos, s"Define the return type for:") // requires explicit return type
+          case v @ ValDef(mods, _, rt, _) if mods.hasFlag(Flag.MUTABLE) => c.abort(v.pos, s"var is not allow in @eff trait $tpname")
+          case v @ ValDef(_, _, rt, EmptyTree)  =>
+            if (!isReturnTypeOfTypeAlias(rt)) c.abort(v.pos, s"Abstract val needs to have return type ${typeAlias.name}[...], otherwise, make it non-abstract.")
+          case d @ DefDef(_, _, _, _, rt, EmptyTree) =>
+            if (!isReturnTypeOfTypeAlias(rt)) c.abort(d.pos, s"Abstract def needs to have return type ${typeAlias.name}[...], otherwise, make it non-abstract.")
+          case _ => // no issue
+        }
+
+        val absValsDefsOps: Seq[ValOrDefDef] = stats.collect {
+          case m @ DefDef(_, _, _, _, ExpectedReturnType(_), EmptyTree) => m
+          case v @ ValDef(_, _, ExpectedReturnType(_), EmptyTree) => v
+        }
+
+        // --------------------------------------------------------------------------------
+        // vals name with op(s) means having return type matching the defined typeAlias.
+        // And vise versa, nonOp(s) means having different return type than the typeAlias.
+        // --------------------------------------------------------------------------------
+
+        val liftedOps:Seq[DefDef] = absValsDefsOps.map {
+          case DefDef(_, name, tparams, paramss, ExpectedReturnType(EffType(effectType, returnType)), _) =>
+            val op = {
+              val args = paramssToArgs(paramss).dropRight(1)
+              val rhs = q"Eff.send[${sealedTrait.name}, $effectType, $returnType](${adt(sealedTrait, name)}(...$args))"
+              val params = (if (paramss.isEmpty) List.empty else paramss)
+              q"def $name[..${tparams}](...$params): Eff[$effectType, $returnType] = $rhs".asInstanceOf[DefDef]
+            }
+            op
+          case ValDef(_, name, rt@AppliedTypeTree(_, innerType), rhs) =>
+            val rhs = q"Eff.send(${adt(sealedTrait, name)})"
+            q"def $name: Eff[..$innerType] = $rhs".asInstanceOf[DefDef]
+        }
+
+        val concreteValsDefs: Seq[ValOrDefDef] = stats.collect {
+          case m @ DefDef(_, _, _, _, _, rhs) if rhs.nonEmpty => m
+          case v @ ValDef(_, _, _, rhs)       if rhs.nonEmpty => v
+        }
+
+        val (concreteOps: Seq[DefDef], concreteNonOps: Seq[ValOrDefDef]) = {
+          val (ops, nonOps) = concreteValsDefs.partition {
+            case DefDef(_, _, _, _, AppliedTypeTree(Ident(outerType), _), _) => outerType == typeAlias.name
+            case ValDef(_, _, AppliedTypeTree(Ident(outerType), _), _)       => outerType == typeAlias.name
+            case _ => false
+          }
+
+
+          // defs that contain the real implementation
+          val injectOps: Seq[DefDef] = ops.map {
+            case DefDef(mods, tname, tp, paramss, AppliedTypeTree(_, innerType), rhs) =>
+              q"$mods def $tname[..$tp](...${paramss}): Eff[..$innerType] = ${rhs}".asInstanceOf[DefDef]
+            case ValDef(mods, tname, AppliedTypeTree(_, innerType), rhs) =>
+              q"$mods def $tname: Eff[..$innerType] = ${rhs}".asInstanceOf[DefDef]
+          }
+
+          (injectOps, nonOps)
+        }
+
+        val injectOpsObj = {
+          q"""
+            object ops {
+              ..$concreteNonOps
+              ..$liftedOps
+              ..$concreteOps
+            }
+           """
+        }
+
+
+        val methodsToBeImpl: Seq[DefDef] = absValsDefsOps.map {
+          case DefDef(mods, name, tparams, paramss, ExpectedReturnType(EffType(_, returnType)), _) =>
+            DefDef(mods, name, tparams.dropRight(1), paramss.take(1), returnType, EmptyTree)
+          case ValDef(mods, name, rt, _) =>
+            DefDef(mods, name, List.empty, List.empty, replaceContainerType(rt, TypeName("M")), EmptyTree)
+        }
+
+        val genCaseClassesAndObjADT = {
+          val caseClasses = absValsDefsOps.collect {
+            case q"$_ def $tname[..$tparams](...$paramss): ${AppliedTypeTree(_, returnType)} = $expr" =>
+              val fixedParams = fixSI88771(paramss)
+              val implicitParams = fixedParams(1).collect {
+                case ValDef(_, _, AppliedTypeTree(Ident(name), Seq(Ident(stackTypeName))), _) if name == typeAlias.name => stackTypeName
+              }
+              val nonStackReturnTypes = returnType.filter {
+                case Ident(name) if implicitParams.contains(name) => false
+                case _ => true
+              }
+              val nonStackTypeParams = tparams.filter {
+                case TypeDef(_, name, _, _) if implicitParams.contains(name) => false
+                case _ => true
+              }
+              val nonStackParams = fixedParams.map { params =>
+                params.filter {
+                  case ValDef(_, _, AppliedTypeTree(Ident(name), _), _) => implicitParams.contains(name)
+                  case _ => true
+                }
+              }.filterNot(_.isEmpty)
+              q"case class ${TypeName(tname.toString.capitalize)}[..$nonStackTypeParams](...$nonStackParams) extends ${sealedTrait.name}[..$nonStackReturnTypes]"
+            case ValDef(_, name, AppliedTypeTree(_, returnType), _) =>
+              q"case object ${TermName(name.toString.capitalize)} extends ${sealedTrait.name}[..$returnType]"
+          }
+          q"object ${sealedTrait.name.toTermName} { ..$caseClasses }"
+        }
+
+        val genCompanionObj =
+          q"""
+            object ${tpname.toTermName} {
+              ..$imports
+              import scala.language.higherKinds
+              $sealedTrait
+              $typeAlias
+              $genCaseClassesAndObjADT
+              ..$injectOpsObj
+              trait SideEffect extends org.atnos.eff.SideEffect[${sealedTrait.name}] {
+                def apply[A](fa: ${sealedTrait.name}[A]): A = fa match {
+                  case ..${absValsDefsOps.map {
+                    case DefDef(_, name, _, paramss, rt, _) =>
+                      val binds = paramss.dropRight(1).flatMap(_.collect { case t:ValDef => Bind (t.name, Ident(termNames.WILDCARD))})
+                      val args = paramss.map(_.collect { case t:ValDef => Ident(t.name.toTermName) })
+                      val rhs = if (args.isEmpty) q"$name" else q"$name(...${args.dropRight(1)})"
+                      cq"${adt(sealedTrait, name)}(..$binds) => $rhs"
+                    case ValDef(_, name, _, _) =>
+                      cq"${adt(sealedTrait, name)} => $name"
+                  }}
+                }
+                def applicative[X, Tr[_] : Traverse](ms: Tr[${sealedTrait.name}[X]]): Tr[X] =
+                  ms.map(apply)
+                def run[R, A](effects: Eff[R, A])(implicit m: ${sealedTrait.name} <= R): Eff[m.Out, A] =
+                  org.atnos.eff.interpret.interpretUnsafe(effects)(this)(m)
+                ..$methodsToBeImpl
+              }
+            }
+           """
+
+        val gen = q"..${List(q"trait $tpname", genCompanionObj)}"
+        println(showCode(gen))
+        c.Expr[Any](gen)
+
+      case other => c.abort(c.enclosingPosition, s"${showRaw(other)}")
+    }
+  }
+
+}

--- a/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
+++ b/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
@@ -83,41 +83,38 @@ class EffMacrosSpec extends Specification { def is = s2"""
     import cats.implicits._
     import cats.data._
 
-    type _writerString[R] = Writer[String, ?] |= R
-    type _stateMap[R]     = State[Map[String, Any], ?] |= R
+    type WriterString[A] = Writer[String, A]
+    type StateMap[A]     = State[Map[String, Any], A]
+    type _writerString[R] = WriterString |= R
+    type _stateMap[R]     = StateMap |= R
 
-    def runKVStore[R, U, A](effects: Eff[R, A])
-      (implicit m: Member.Aux[KVStore, R, U],
-        throwable:_throwableEither[U],
-        writer:_writerString[U],
-        state:_stateMap[U]): Eff[U, A] = {
 
-      val tr = new KVStoreDsl.Translate[R, U] {
-        def put[T](key: String, value: T)(implicit ordering: Ordering[T]): Eff[U, Unit] = for {
-          _ <- tell(s"put($key, $value)")
-          _ <- modify((map: Map[String, Any]) => map.updated(key, value))
-          r <- fromEither(Either.catchNonFatal(()))
-        } yield r
-        def get[T](key: String): Eff[U, GetResult[T]] = for {
-          _ <- tell(s"get($key)")
-          m <- StateEffect.get[U, Map[String, Any]]
-          r <- fromEither(Either.catchNonFatal(m.get(key).map(_.asInstanceOf[T])))
-        } yield GetResult(r)
-        def delete[T](key: String): Eff[U, Unit] = for {
-          _ <- tell(s"delete($key)")
-          u <- modify((map: Map[String, Any]) => map - key)
-          r <- fromEither(Either.catchNonFatal(()))
-        } yield r
+    val tr = new KVStoreDsl.TranslatorFactory3[ThrowableEither, WriterString, StateMap] {
+      def put[T : Ordering, U : _throwableEither : _writerString : _stateMap](key: String, value: T): Eff[U, Unit] = for {
+        _ <- tell(s"put($key, $value)").into[U]
+        _ <- modify((map: Map[String, Any]) => map.updated(key, value)).into[U]
+        r <- fromEither(Either.catchNonFatal(())).into[U]
+      } yield r
+      def get[T, U : _throwableEither : _writerString : _stateMap](key: String): Eff[U, GetResult[T]] = for {
+        _ <- tell(s"get($key)").into[U]
+        m <- StateEffect.get[U, Map[String, Any]].into[U]
+        r <- fromEither(Either.catchNonFatal(m.get(key).map(_.asInstanceOf[T]))).into[U]
+      } yield GetResult(r)
+      def delete[T, U : _throwableEither : _writerString : _stateMap](key: String): Eff[U, Unit] = for {
+        _ <- tell(s"delete($key)").into[U]
+        u <- modify((map: Map[String, Any]) => map - key).into[U]
+        r <- fromEither(Either.catchNonFatal(())).into[U]
+      } yield r
 
-      }
-      translate(effects)(tr)
     }
 
     // run the program with the safe interpreter
     type Stack = Fx.fx4[KVStore, Throwable Either ?, State[Map[String, Any], ?], Writer[String, ?]]
 
+    // The TranslatorFactory instance contains an implicit class that provides the runKVStore method on the program
+    import tr._
     val (result, logs) =
-      runKVStore(program[Stack]).runEither.evalState(Map.empty[String, Any]).runWriter.run
+      program[Stack].runKVStore.runEither.evalState(Map.empty[String, Any]).runWriter.run
 
     result ==== Right(Some(14))
   }

--- a/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
+++ b/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
@@ -32,7 +32,7 @@ class EffMacrosSpec extends Specification { def is = s2"""
       } yield ()
   }
 
-  import KVStoreDsl._, ops._
+  import KVStoreDsl._
   import org.atnos.eff._
 
   def program[R :_kvstore]: Eff[R, Option[Int]] =
@@ -80,7 +80,6 @@ class EffMacrosSpec extends Specification { def is = s2"""
     import org.atnos.eff._, all._, interpret._
     import cats.implicits._
     import cats.data._
-    import KVStore._
 
     type _writerString[R] = Writer[String, ?] |= R
     type _stateMap[R]     = State[Map[String, Any], ?] |= R
@@ -124,7 +123,6 @@ class EffMacrosSpec extends Specification { def is = s2"""
   }
 
   def generatesNaturalTransformationInterpreter = {
-    import KVStore._
     import org.atnos.eff._, all._
     import org.atnos.eff.syntax.all._
 

--- a/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
+++ b/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
@@ -13,44 +13,49 @@ import Eff._
 class EffMacrosSpec extends Specification { def is = s2"""
 
  generates boilerplate code for custom effects $generatesBoilerplate
-
+ generates a SideEffect sub-class with boilerplate-free methods $generatesSideEffectInterpreter
+ generates a Translate sub-trait with boilerplate-free methods $generatesTranslateInterpreter
 """
+  @eff trait KVStoreDsl {
+    type _kvstore[R] = KVStore MemberIn R
+
+    sealed trait KVStore[+A]
+
+    def put[T : Ordering, R :_kvstore](key: String, value: T): Eff[R, Unit]
+    def get[T, R :_kvstore](key: String): Eff[R, Option[T]]
+    def delete[T, R :_kvstore](key: String): Eff[R, Unit]
+    def update[T : Ordering, R :_kvstore](key: String, f: T => T): Eff[R, Unit] =
+      for {
+        vMaybe <- get[T, R](key)
+        _ <- vMaybe.map(v => put[T, R](key, f(v))).getOrElse(Eff.pure(()))
+      } yield ()
+  }
+
+  import KVStoreDsl._, ops._
+  import org.atnos.eff._
+
+  def program[R :_kvstore]: Eff[R, Option[Int]] =
+    for {
+      _ <- put("wild-cats", 2)
+      _ <- update[Int, R]("wild-cats", _ + 12)
+      _ <- put("tame-cats", 5)
+      n <- get[Int, R]("wild-cats")
+      _ <- delete("tame-cats")
+    } yield n
+  lazy val theProgram = program[Fx.fx1[KVStore]]
 
   def generatesBoilerplate = {
+    theProgram should beAnInstanceOf[Eff[Fx1[KVStore],Option[Int]]]
+  }
 
-    @eff trait KVStoreDsl {
-      type _kvstore[R] = KVStore MemberIn R
-
-      sealed trait KVStore[+A]
-
-      def put[T, R :_kvstore](key: String, value: T): Eff[R, Unit]
-      def get[T, R :_kvstore](key: String): Eff[R, Option[T]]
-      def delete[T, R :_kvstore](key: String): Eff[R, Unit]
-      def update[T, R :_kvstore](key: String, f: T => T): Eff[R, Unit] =
-        for {
-          vMaybe <- get[T, R](key)
-          _ <- vMaybe.map(v => put[T, R](key, f(v))).getOrElse(Eff.pure(()))
-        } yield ()
-    }
-
-    import KVStoreDsl._, ops._
-    import org.atnos.eff._
-
-    def program[R :_kvstore]: Eff[R, Option[Int]] =
-      for {
-        _ <- put("wild-cats", 2)
-        _ <- update[Int, R]("wild-cats", _ + 12)
-        _ <- put("tame-cats", 5)
-        n <- get[Int, R]("wild-cats")
-        _ <- delete("tame-cats")
-      } yield n
+  def generatesSideEffectInterpreter = {
 
     import org.atnos.eff._, interpret._
     import scala.collection.mutable._
 
     val sideEffect = new KVStoreDsl.SideEffect {
       val kvs = Map.empty[String, Any]
-      def put[T](key: String, value: T): Unit = {
+      def put[T : Ordering](key: String, value: T): Unit = {
         kvs.put(key, value)
         ()
       }
@@ -66,7 +71,54 @@ class EffMacrosSpec extends Specification { def is = s2"""
     import org.atnos.eff._, syntax.all._
 
     // run the program with the unsafe interpreter
-    val result = sideEffect.run(program[Fx.fx1[KVStore]]).run
+    val result = sideEffect.run(theProgram).run
     result ==== Some(14)
+  }
+
+  def generatesTranslateInterpreter = {
+    import org.atnos.eff._, all._, interpret._
+    import cats.implicits._
+    import cats.data._
+    import KVStore._
+
+    type _writerString[R] = Writer[String, ?] |= R
+    type _stateMap[R]     = State[Map[String, Any], ?] |= R
+
+    def runKVStore[R, U, A](effects: Eff[R, A])
+      (implicit m: Member.Aux[KVStore, R, U],
+        throwable:_throwableEither[U],
+        writer:_writerString[U],
+        state:_stateMap[U]): Eff[U, A] = {
+
+      val tr = new KVStoreDsl.Translate[R, U] {
+        def put[T](key: String, value: T)(implicit ordering: Ordering[T]): Eff[U, Unit] = for {
+          _ <- tell(s"put($key, $value)")
+          _ <- modify((map: Map[String, Any]) => map.updated(key, value))
+          r <- fromEither(Either.catchNonFatal(()))
+        } yield r
+        def get[T](key: String): Eff[U, Option[T]] = for {
+          _ <- tell(s"get($key)")
+          m <- StateEffect.get[U, Map[String, Any]]
+          r <- fromEither(Either.catchNonFatal(m.get(key).map(_.asInstanceOf[T])))
+        } yield r
+        def delete[T](key: String): Eff[U, Unit] = for {
+          _ <- tell(s"delete($key)")
+          u <- modify((map: Map[String, Any]) => map - key)
+          r <- fromEither(Either.catchNonFatal(()))
+        } yield r
+
+      }
+      translate(effects)(tr)
+    }
+    import org.atnos.eff._, syntax.all._
+    import cats._, data._
+
+    // run the program with the safe interpreter
+    type Stack = Fx.fx4[KVStore, Throwable Either ?, State[Map[String, Any], ?], Writer[String, ?]]
+
+    val (result, logs) =
+      runKVStore(program[Stack]).runEither.evalState(Map.empty[String, Any]).runWriter.run
+
+    result ==== Right(Some(14))
   }
 }

--- a/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
+++ b/macros/src/test/scala/org/atnos/eff/macros/EffMacrosSpec.scala
@@ -1,0 +1,72 @@
+package org.atnos.eff.macros
+
+import org.specs2.Specification
+import org.atnos.eff._
+import cats.syntax.all._
+import cats.data._
+import cats.{Eval, Traverse}
+import ReaderEffect._
+import WriterEffect._
+import EvalEffect._
+import Eff._
+
+class EffMacrosSpec extends Specification { def is = s2"""
+
+ generates boilerplate code for custom effects $generatesBoilerplate
+
+"""
+
+  def generatesBoilerplate = {
+
+    @eff trait KVStoreDsl {
+      type _kvstore[R] = KVStore MemberIn R
+
+      sealed trait KVStore[+A]
+
+      def put[T, R :_kvstore](key: String, value: T): Eff[R, Unit]
+      def get[T, R :_kvstore](key: String): Eff[R, Option[T]]
+      def delete[T, R :_kvstore](key: String): Eff[R, Unit]
+      def update[T, R :_kvstore](key: String, f: T => T): Eff[R, Unit] =
+        for {
+          vMaybe <- get[T, R](key)
+          _ <- vMaybe.map(v => put[T, R](key, f(v))).getOrElse(Eff.pure(()))
+        } yield ()
+    }
+
+    import KVStoreDsl._, ops._
+    import org.atnos.eff._
+
+    def program[R :_kvstore]: Eff[R, Option[Int]] =
+      for {
+        _ <- put("wild-cats", 2)
+        _ <- update[Int, R]("wild-cats", _ + 12)
+        _ <- put("tame-cats", 5)
+        n <- get[Int, R]("wild-cats")
+        _ <- delete("tame-cats")
+      } yield n
+
+    import org.atnos.eff._, interpret._
+    import scala.collection.mutable._
+
+    val sideEffect = new KVStoreDsl.SideEffect {
+      val kvs = Map.empty[String, Any]
+      def put[T](key: String, value: T): Unit = {
+        kvs.put(key, value)
+        ()
+      }
+      def get[T](key: String): Option[T] = {
+        kvs.get(key).asInstanceOf[Option[T]]
+      }
+      def delete[T](key: String): Unit = {
+        kvs.remove(key)
+        ()
+      }
+    }
+
+    import org.atnos.eff._, syntax.all._
+
+    // run the program with the unsafe interpreter
+    val result = sideEffect.run(program[Fx.fx1[KVStore]]).run
+    result ==== Some(14)
+  }
+}


### PR DESCRIPTION
**This is still WIP**

We are doing our first steps with free monads and have previously been using the corresponding cats implementation. To reduce the amount of required boilerplate, we used the very nice [Freasy-Monad library](https://github.com/Thangiee/Freasy-Monad) on top of cats.

As we're currently evaluating switching over to eff (mostly because stack transformations seem much nicer) and we liked the "macro generates the boilerplate" approach, we ported the Freasy-Monad (MIT licensed) code to work with eff.

The macro reads the method definitions from a `@eff trait` and generates the corresponding ADT `case classes`, a `SideEffect`, `Translate` and a `FunctionK` sub-trait which the user then has to fill with methods that resemble the methods from the `@eff trait`.

The tests resemble the tutorial and show what the user still needs to implement.

We're happy about any feedback!