### PR TITLE
Detach with last

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -281,7 +281,7 @@ lazy val catsVersion   = "0.9.0"
 lazy val monixVersion  = "2.1.0"
 lazy val scalazVersion = "7.2.7"
 lazy val fs2Version    = "0.9.2"
-lazy val specs2Version = "3.8.7"
+lazy val specs2Version = "3.8.9"
 lazy val twitterUtilVersion = "6.42.0"
 lazy val catbirdVersion = "0.13.0"
 

--- a/jvm/src/test/scala/org/atnos/eff/ContinuationSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ContinuationSpec.scala
@@ -7,16 +7,16 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck._
 import org.specs2.{ScalaCheck, Specification}
 
-class ArrsSpec extends Specification with ScalaCheck { def is = s2"""
+class ContinuationSpec extends Specification with ScalaCheck { def is = s2"""
 
  A function can run at the end of a Kleisli arrow into the Eff monad $mapLast
 
-  """
+"""
 
   def mapLast = prop { xs: List[Int] =>
     type R = Fx.fx1[Eval]
     val plusOne = Continuation.unit[R, Int].mapLast(_.map(_ + 1))
-    xs.traverseA(plusOne).detach.value ==== xs.map(_ + 1)
+    xs.traverseA(plusOne).runEval.run ==== xs.map(_ + 1)
   }.setGen(Gen.listOf(Gen.oneOf(1, 2, 3)))
 
-  }
+}

--- a/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
@@ -178,7 +178,7 @@ class EffSpec extends Specification with ScalaCheck { def is = s2"""
     type S = Fx.append[Fx.fx2[Writer[Int, ?], Either[String, ?]], Fx.fx1[Option]]
     val e: Eff[S, Int] = OptionEffect.some[S, Int](1)
 
-    e.runWriter.runEither.detachA(Applicative[Option]) must beSome(Right((1, Nil)))
+    e.runWriter.runEither.detachA(Applicative[Option]) must beSome(Right[String, (Int, List[Int])]((1, Nil)))
   }
 
   def traverseEff = {

--- a/jvm/src/test/scala/org/atnos/eff/EvalEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EvalEffectSpec.scala
@@ -39,7 +39,7 @@ class EvalEffectSpec extends Specification { def is = s2"""
         Eval.now(eval.defer(loop(i - 1)).map(_  + 1))
       }
 
-    loop(100000).value.detach.value ==== 100001
+    loop(100000).value.runEval.run ==== 100001
   }
 }
 

--- a/jvm/src/test/scala/org/atnos/eff/FutureEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/FutureEffectSpec.scala
@@ -162,7 +162,7 @@ class FutureEffectSpec(implicit ee: ExecutionEnv) extends Specification with Sca
 
   def e14 = {
     type S = Fx2[TimedFuture, Option]
-    var lastActionDone = false
+    var lastActionDone = 0
 
     val action: Eff[S, Int] =
       for {
@@ -173,11 +173,11 @@ class FutureEffectSpec(implicit ee: ExecutionEnv) extends Specification with Sca
 
     val execute: Eff[S, Throwable Either Int] =
       action.
-        addLast(futureDelay[S, Unit](lastActionDone = true)).
+        addLast(futureDelay[S, Unit](lastActionDone += 1)).
         futureAttempt
 
     execute.runOption.runSequential must beSome(beLeft[Throwable]).awaitFor(20.seconds)
-    lastActionDone must beTrue
+    lastActionDone must beEqualTo(1)
   }
 
   def e15 = {

--- a/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
+++ b/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
@@ -49,8 +49,8 @@ object TaskCreation extends TaskCreation
 
 trait TaskInterpretation extends TaskTypes {
 
-  private val monixTaskMonad: Monad[Task] =
-    Monad[Task]
+  private val monixTaskMonad: MonadError[Task, Throwable] =
+    monix.cats.monixToCatsMonadError(Task.typeClassInstances.monadError)
 
   private val monixTaskApplicative : Applicative[Task] =
     monixToCatsApplicative(Task.nondeterminism.applicative)

--- a/shared/src/main/scala/org/atnos/eff/syntax/eff.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/eff.scala
@@ -66,10 +66,10 @@ final class EffPureOps[A](val a: A) extends AnyVal {
 }
 
 final class EffOneEffectOps[M[_], A](val e: Eff[Fx1[M], A]) extends AnyVal {
-  def detach(implicit M: Monad[M]): M[A] =
+  def detach[E](implicit M: MonadError[M, E]): M[A] =
     Eff.detach(e)
 
-  def detachA(applicative: Applicative[M])(implicit monad: Monad[M]): M[A] =
+  def detachA[E](applicative: Applicative[M])(implicit monad: MonadError[M, E]): M[A] =
     Eff.detachA(e)(monad, applicative)
 }
 


### PR DESCRIPTION
@edmundnoble `MonadError` needs to be used with `detach` in order to make sure that `Last` actions are indeed being triggered when `Future` or `Task` are failing.