### PR TITLE
Moved the Scheduler trait to a concurrent package

### DIFF
--- a/fs2/shared/src/main/scala/org/atnos/eff/addon/fs2/TaskEffect.scala
+++ b/fs2/shared/src/main/scala/org/atnos/eff/addon/fs2/TaskEffect.scala
@@ -3,7 +3,7 @@ package org.atnos.eff.addon.fs2
 import cats._
 import cats.implicits._
 import fs2._
-import org.atnos.eff.{Scheduler => _, _}
+import org.atnos.eff._
 import org.atnos.eff.syntax.all._
 
 import scala.concurrent.duration.FiniteDuration

--- a/js/src/main/scala/org/atnos/eff/concurrent/Schedulers.scala
+++ b/js/src/main/scala/org/atnos/eff/concurrent/Schedulers.scala
@@ -1,4 +1,4 @@
-package org.atnos.eff
+package org.atnos.eff.concurrent
 
 import scala.concurrent.duration.FiniteDuration
 import scala.scalajs.js.timers._

--- a/jvm/src/main/scala/org/atnos/eff/Schedulers.scala
+++ b/jvm/src/main/scala/org/atnos/eff/Schedulers.scala
@@ -1,3 +1,0 @@
-package org.atnos.eff
-
-trait Schedulers

--- a/jvm/src/main/scala/org/atnos/eff/concurrent/Schedulers.scala
+++ b/jvm/src/main/scala/org/atnos/eff/concurrent/Schedulers.scala
@@ -1,0 +1,3 @@
+package org.atnos.eff.concurrent
+
+trait Schedulers

--- a/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
+++ b/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import monix.eval._
 import monix.cats._
 import monix.execution._
-import org.atnos.eff.{Scheduler => _, _}
+import org.atnos.eff._
 import org.atnos.eff.syntax.all._
 
 import scala.concurrent.duration.FiniteDuration

--- a/notes/3.1.0.markdown
+++ b/notes/3.1.0.markdown
@@ -2,12 +2,12 @@ This version brings some breaking API changes for async effects in order to make
 
 ## Changes
    
- * `TimedFuture`, `TwitterTimedFuture`, scalaz `TimedTask`, fs2 `TimedTask` now use a `org.atnos.eff.Scheduler` instead of a `ScheduledExecutorService` to
+ * `TimedFuture`, `TwitterTimedFuture`, scalaz `TimedTask`, fs2 `TimedTask` now use a `org.atnos.eff.concurrent.Scheduler` instead of a `ScheduledExecutorService` to
  timeout computations
  
  * a `Scheduler` can be created from a `ScheduledExecutorService` with the `ExecutorServices.schedulerFromScheduledExecutorService` method for the JVM
  
- * a `Scheduler` can be created with the `org.atnos.eff.Schedulers.default` method for ScalaJS
+ * a `Scheduler` can be created with the `org.atnos.eff.concurrent.Schedulers.default` method for ScalaJS
  
  * the monix `Task` effect is now directly using the `monix.eval.Task` type instead of using a `TimedTask` type before. 
  The API stays the same except for stacks declarations which are now `Fx.fx1[Task]` instead of `Fx.fx1[TimedTask]`

--- a/shared/src/main/scala/org/atnos/eff/ExecutorServices.scala
+++ b/shared/src/main/scala/org/atnos/eff/ExecutorServices.scala
@@ -4,6 +4,7 @@ import java.util.Collections
 import java.util.concurrent._
 
 import cats.Eval
+import org.atnos.eff.concurrent.{Scheduler, Schedulers}
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}

--- a/shared/src/main/scala/org/atnos/eff/FutureEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/FutureEffect.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeoutException
 import cats._
 import cats.implicits._
 import org.atnos.eff.all._
+import org.atnos.eff.concurrent.Scheduler
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future, Promise}

--- a/shared/src/main/scala/org/atnos/eff/concurrent/Scheduler.scala
+++ b/shared/src/main/scala/org/atnos/eff/concurrent/Scheduler.scala
@@ -1,6 +1,6 @@
-package org.atnos.eff
+package org.atnos.eff.concurrent
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * The design of the Scheduler is taken from:

--- a/shared/src/main/scala/org/atnos/eff/syntax/future.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/future.scala
@@ -1,6 +1,7 @@
 package org.atnos.eff.syntax
 
 import org.atnos.eff._
+import org.atnos.eff.concurrent.Scheduler
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/twitter/src/main/scala/org/atnos/eff/addon/twitter/TwitterFutureEffect.scala
+++ b/twitter/src/main/scala/org/atnos/eff/addon/twitter/TwitterFutureEffect.scala
@@ -8,6 +8,7 @@ import org.atnos.eff._
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.TimeoutException
 import com.twitter.util._
+import org.atnos.eff.concurrent.Scheduler
 
 object TwitterFutureCreation extends TwitterFutureCreation
 

--- a/twitter/src/main/scala/org/atnos/eff/syntax/addon/twitter/future.scala
+++ b/twitter/src/main/scala/org/atnos/eff/syntax/addon/twitter/future.scala
@@ -3,6 +3,7 @@ package org.atnos.eff.syntax.addon.twitter
 import com.twitter.util.{Future, FuturePool}
 import org.atnos.eff.addon.twitter._
 import org.atnos.eff._
+import org.atnos.eff.concurrent.Scheduler
 
 trait future {
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.3.5"
+version in ThisBuild := "4.4.0"


### PR DESCRIPTION
to avoid clashes with Monix's Scheduler.

@benhutchison I couldn't find a better name so I opted for a package move which should fix the conflict when importing `org.atnos.eff._`.

Review @edmundnoble 