### PR TITLE
Migrated the code to cats 1.0.0-MF

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,21 +8,22 @@ import Defaults.{defaultTestTasks, testTaskOptions}
 import sbtrelease._
 import org.scalajs.jsenv.nodejs._
 
-lazy val catsVersion        = "0.9.0"
-lazy val monixVersion       = "2.3.0"
+lazy val catsVersion        = "1.0.0-MF"
+lazy val monixVersion       = "3.0.0-22bf9c6"
 lazy val scalazVersion      = "7.2.7"
 lazy val fs2Version         = "0.9.6"
-lazy val specs2Version      = "4.0.0-RC3"
+lazy val specs2Version      = "4.0.0-RC4"
 lazy val twitterUtilVersion = "6.42.0"
 lazy val catbirdVersion     = "0.13.0"
 lazy val doobieVersion      = "0.4.4"
+lazy val catsEffectVersion  = "0.4"
 
 lazy val eff = project.in(file("."))
   .settings(moduleName := "root")
   .settings(effSettings)
   .settings(noPublishSettings)
-  .aggregate(coreJVM, coreJS, doobie, macros, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
-  .dependsOn(coreJVM, coreJS, doobie, macros, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
+  .aggregate(coreJVM, coreJS, doobie, cats, macros, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
+  .dependsOn(coreJVM, coreJS, doobie, cats, macros, monixJVM, monixJS, scalaz, twitter, fs2JS, fs2JVM)
 
 lazy val core = crossProject.crossType(CrossType.Full).in(file("."))
   .settings(moduleName := "eff")
@@ -39,6 +40,12 @@ lazy val doobie = project
   .settings(moduleName := "eff-doobie")
   .dependsOn(coreJVM)
   .settings(libraryDependencies ++= doobieJvm)
+  .settings(effSettings ++ commonJvmSettings:_*)
+
+lazy val cats = project.in(file("cats"))
+  .settings(moduleName := "eff-cats-effect")
+  .dependsOn(coreJVM)
+  .settings(libraryDependencies ++= catsEffectJvm)
   .settings(effSettings ++ commonJvmSettings:_*)
 
 lazy val macros = project.in(file("macros"))
@@ -307,13 +314,14 @@ lazy val doobieJvm = Seq(
   "org.tpolecat" %% "doobie-core-cats" % doobieVersion,
   "org.tpolecat" %% "doobie-h2-cats"   % doobieVersion % "test")
 
+lazy val catsEffectJvm = Seq(
+  "org.typelevel" %% "cats-effect" % catsEffectVersion)
+
 lazy val monixEval = Seq(
-  "io.monix" %% "monix-eval" % monixVersion,
-  "io.monix" %% "monix-cats" % monixVersion)
+  "io.monix" %% "monix-eval" % monixVersion)
 
 lazy val monixJs = Seq(
-  "io.monix" %%%! "monix-eval" % monixVersion,
-  "io.monix" %%%! "monix-cats" % monixVersion)
+  "io.monix" %%%! "monix-eval" % monixVersion)
 
 lazy val scalazConcurrent = Seq(
   "org.scalaz" %% "scalaz-concurrent" % scalazVersion)

--- a/cats/src/main/scala/org/atnos/eff/addon/cats/effect/IOEffect.scala
+++ b/cats/src/main/scala/org/atnos/eff/addon/cats/effect/IOEffect.scala
@@ -1,0 +1,78 @@
+package org.atnos.eff.addon.cats.effect
+
+import cats.effect.{Async, IO}
+import IO._
+
+import cats.~>
+import org.atnos.eff._
+import org.atnos.eff.syntax.eff._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+
+object IOEffect extends IOEffectCreation with IOInterpretation
+
+trait IOTypes {
+
+  type _io[R] = |=[IO, R]
+  type _Io[R] = <=[IO, R]
+
+}
+
+
+trait IOEffectCreation extends IOTypes {
+
+  final def fromIO[R :_io, A](io: IO[A]): Eff[R, A] =
+    io.send[R]
+
+  final def ioRaiseError[R :_io, A](t: Throwable): Eff[R, A] =
+    IO.ioEffect.raiseError(t).send[R]
+
+  final def ioDelay[R :_io, A](io: =>A): Eff[R, A] =
+    IO.ioEffect.delay(io).send[R]
+
+  final def ioFork[R :_io, A](io: =>A)(implicit ec: ExecutionContext): Eff[R, A] =
+    ioShift >> ioDelay(io)
+
+  final def ioSuspend[R :_io, A](io: =>IO[Eff[R, A]]): Eff[R, A] =
+    IO.ioEffect.suspend(io).send[R].flatten
+
+  final def ioShift[R :_io](implicit ec: ExecutionContext): Eff[R, Unit] =
+    IO.ioEffect.shift(ec).send[R]
+
+}
+
+trait IOInterpretation extends IOTypes {
+
+  def runAsync[R, A](e: Eff[R, A])(cb: Either[Throwable, A] => IO[Unit])(implicit m: Member.Aux[IO, R, NoFx]): IO[Unit] =
+    Eff.detach(e).runAsync(cb)
+
+  def unsafeRunAsync[R, A](e: Eff[R, A])(cb: Either[Throwable, A] => Unit)(implicit m: Member.Aux[IO, R, NoFx]): Unit =
+    Eff.detach(e).unsafeRunAsync(cb)
+
+  def unsafeRunSync[R, A](e: Eff[R, A])(implicit m: Member.Aux[IO, R, NoFx]): A =
+    Eff.detach(e).unsafeRunSync
+
+  def unsafeRunTimed[R, A](e: Eff[R, A], limit: Duration)(implicit m: Member.Aux[IO, R, NoFx]): Option[A] =
+    Eff.detach(e).unsafeRunTimed(limit)
+
+  def unsafeToFuture[R, A](e: Eff[R, A])(implicit m: Member.Aux[IO, R, NoFx]): Future[A] =
+    Eff.detach(e).unsafeToFuture
+
+  def to[R, F[_], A](e: Eff[R, A])(implicit f: Async[F], m: Member.Aux[IO, R, NoFx]): F[A] =
+    Eff.detach[IO, R, A, Throwable](e).to[F]
+
+  import interpret.of
+
+  def ioAttempt[R, A](e: Eff[R, A])(implicit m: MemberInOut[IO, R]): Eff[R, Throwable Either A] = {
+    import cats.instances.either._
+
+    interpret.interceptNatM[R, IO, Throwable Either ?, A](e,
+      new (IO ~> (IO of (Throwable Either ?))#l) {
+        def apply[X](io: IO[X]): IO[Throwable Either X] =
+          io.attempt
+      })
+  }
+}
+
+

--- a/cats/src/main/scala/org/atnos/eff/syntax/addon/cats/effect/effect.scala
+++ b/cats/src/main/scala/org/atnos/eff/syntax/addon/cats/effect/effect.scala
@@ -1,0 +1,42 @@
+package org.atnos.eff.syntax.addon.cats
+
+import cats.effect.{Async, IO}
+import org.atnos.eff._
+import org.atnos.eff.addon.cats.effect.IOEffect
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.Duration
+import org.atnos.eff.Eff
+
+object effect {
+
+  implicit final def toIOOps[R, A](e: Eff[R, A]): IOOps[R, A] = new IOOps[R, A](e)
+
+}
+
+final class IOOps[R, A](val e: Eff[R, A]) extends AnyVal {
+
+  def runAsync(cb: Either[Throwable, A] => IO[Unit])(implicit m: Member.Aux[IO, R, NoFx]): IO[Unit] =
+    IOEffect.runAsync(e)(cb)
+
+  def unsafeRunAsync(cb: Either[Throwable, A] => Unit)(implicit m: Member.Aux[IO, R, NoFx]): Unit =
+    IOEffect.unsafeRunAsync(e)(cb)
+
+  def unsafeRunSync(implicit m: Member.Aux[IO, R, NoFx]): A =
+    IOEffect.unsafeRunSync(e)
+
+  def unsafeRunTimed(limit: Duration)(implicit m: Member.Aux[IO, R, NoFx]): Option[A] =
+    IOEffect.unsafeRunTimed(e, limit)
+
+  def unsafeToFuture(implicit m: Member.Aux[IO, R, NoFx]): Future[A] =
+    IOEffect.unsafeToFuture(e)
+
+  def to[F[_]](implicit f: Async[F], m: Member.Aux[IO, R, NoFx]): F[A] =
+    IOEffect.to(e)
+
+  def ioAttempt(implicit m: MemberInOut[IO, R]): Eff[R, Throwable Either A] =
+    IOEffect.ioAttempt(e)
+
+  def ioShift(implicit m: MemberIn[IO, R], ec: ExecutionContext): Eff[R, A] =
+    IOEffect.ioShift >> e
+}

--- a/cats/src/test/scala/org/atnos/eff/addon/cats/effect/IOEffectSpec.scala
+++ b/cats/src/test/scala/org/atnos/eff/addon/cats/effect/IOEffectSpec.scala
@@ -1,0 +1,84 @@
+package org.atnos.eff.addon.cats.effect
+
+import cats.implicits._
+import org.atnos.eff.all._
+import org.atnos.eff.syntax.all._
+import org.specs2._
+import org.specs2.concurrent.ExecutionEnv
+
+import org.atnos.eff._
+import cats.effect.IO
+import IOEffect._
+import org.atnos.eff.syntax.addon.cats.effect._
+import scala.concurrent.duration._
+
+class IOEffectSpec(implicit ee: ExecutionEnv) extends Specification with ScalaCheck { def is = "io".title ^ sequential ^ s2"""
+
+ IO effects can work as normal values                    $e1
+ IO effects can be attempted                             $e2
+ IO effects are stacksafe with recursion                 $e3
+
+ Async boundaries can be introduced between computations $e4
+ IO effect is stacksafe with traverseA                   $e5
+
+"""
+
+  type S = Fx.fx2[IO, Option]
+
+  def e1 = {
+    def action[R :_io :_option]: Eff[R, Int] = for {
+      a <- ioDelay(10)
+      b <- ioDelay(20)
+    } yield a + b
+
+    action[S].runOption.unsafeRunTimed(5.seconds).flatten must beSome(30)
+  }
+
+  def e2 = {
+    def action[R :_io :_option]: Eff[R, Int] = for {
+      a <- ioDelay(10)
+      b <- ioDelay { boom; 20 }
+    } yield a + b
+
+    action[S].ioAttempt.runOption.unsafeRunTimed(5.seconds).flatten must beSome(beLeft(boomException))
+  }
+
+  def e3 = {
+    type R = Fx.fx1[IO]
+
+    def loop(i: Int): IO[Eff[R, Int]] =
+      if (i == 0) IO.pure(Eff.pure(1))
+      else IO.pure(ioSuspend(loop(i - 1)).map(_ + 1))
+
+    ioSuspend(loop(1000)).unsafeRunSync must not(throwAn[Exception])
+  }
+
+  def e4 = {
+    def action[R :_io :_option]: Eff[R, Int] = for {
+      a <- ioDelay(10).ioShift
+      b <- ioDelay(20)
+    } yield a + b
+
+    action[S].runOption.unsafeRunTimed(5.seconds).flatten must beSome(30)
+  }
+
+  def e5 = {
+    val action = (1 to 5000).toList.traverseA { i =>
+      if (i % 5 == 0) ioDelay(i).ioShift
+      else            ioDelay(i)
+    }
+
+    action.unsafeRunAsync(_ => ()) must not(throwA[Throwable])
+  }
+
+  /**
+   * HELPERS
+   */
+  def boom: Unit = throw boomException
+  val boomException: Throwable = new Exception("boom")
+
+  def sleepFor(duration: FiniteDuration) =
+    try Thread.sleep(duration.toMillis) catch { case t: Throwable => () }
+
+}
+

--- a/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EffSpec.scala
@@ -10,18 +10,10 @@ import cats.instances.all._
 import cats.Eq
 import cats.~>
 import org.atnos.eff.all._
-import org.atnos.eff.concurrent.Scheduler
-import org.atnos.eff.future._
 import org.atnos.eff.syntax.all._
-import org.atnos.eff.syntax.future._
-import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.ThrownExpectations
 
-import scala.concurrent._
-import duration._
-import scala.collection.mutable.ListBuffer
-
-class EffSpec(implicit ee: ExecutionEnv) extends Specification with ScalaCheck with ThrownExpectations { def is = s2"""
+class EffSpec extends Specification with ScalaCheck with ThrownExpectations { def is = s2"""
 
  The Eff monad respects the laws            $laws
 
@@ -375,8 +367,5 @@ class EffSpec(implicit ee: ExecutionEnv) extends Specification with ScalaCheck w
     def eqv(x: F[(Int, Int, Int)], y:F[(Int, Int, Int)]): Boolean =
       runOption(x).run == runOption(y).run
   }
-
-  implicit val scheduler: Scheduler =
-    ExecutorServices.schedulerFromGlobalExecutionContext
 
 }

--- a/jvm/src/test/scala/org/atnos/eff/EvalEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/EvalEffectSpec.scala
@@ -22,12 +22,12 @@ class EvalEffectSpec extends Specification { def is = s2"""
   val list = (1 to 5000).toList
 
   def stacksafeRun = {
-    val action = list.traverseU(i => EvalEffect.delay(i))
+    val action = list.traverse(i => EvalEffect.delay(i))
     action.runEval.run ==== list
   }
 
   def stacksafeAttempt = {
-    val action = list.traverseU(i => EvalEffect.delay(i))
+    val action = list.traverse(i => EvalEffect.delay(i))
     action.attemptEval.run ==== Right(list)
   }
 

--- a/jvm/src/test/scala/org/atnos/eff/ListEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ListEffectSpec.scala
@@ -40,7 +40,7 @@ class ListEffectSpec extends Specification { def is = s2"""
     val list = (1 to 5000).toList
 
     val action: Eff[L, List[Int]] =
-      list.traverseU(i => singleton[L, Int](i))
+      list.traverse(i => singleton[L, Int](i))
 
     action.runList.run.flatten must_== list
   }

--- a/jvm/src/test/scala/org/atnos/eff/OptionEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/OptionEffectSpec.scala
@@ -62,7 +62,7 @@ class OptionEffectSpec extends Specification with ScalaCheck { def is = s2"""
 
   def stacksafeOption = {
     val list = (1 to 5000).toList
-    val action = list.traverseU(i => OptionEffect.some(i))
+    val action = list.traverse(i => OptionEffect.some(i))
 
     action.runOption.run ==== Some(list)
   }

--- a/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
@@ -73,7 +73,7 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
 
   def stacksafeRun = {
     val list = (1 to 5000).toList
-    val action = list.traverseU(i => ValidateEffect.wrong[S, String](i.toString))
+    val action = list.traverse(i => ValidateEffect.wrong[S, String](i.toString))
 
     action.runNel.run must not(throwAn[Exception])
   }

--- a/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
+++ b/monix/shared/src/main/scala/org/atnos/eff/addon/monix/TaskEffect.scala
@@ -3,7 +3,6 @@ package org.atnos.eff.addon.monix
 import cats._
 import cats.implicits._
 import monix.eval._
-import monix.cats._
 import monix.execution._
 import org.atnos.eff._
 import org.atnos.eff.syntax.all._
@@ -60,10 +59,12 @@ object TaskCreation extends TaskCreation
 trait TaskInterpretation extends TaskTypes {
 
   private val monixTaskMonad: MonadError[Task, Throwable] =
-    monix.cats.monixToCatsMonadError(Task.typeClassInstances.monadError)
+    MonadError[Task, Throwable]
 
-  private val monixTaskApplicative : Applicative[Task] =
-    monixToCatsApplicative(Task.nondeterminism.applicative)
+  private val monixTaskApplicative : Applicative[Task] = {
+    import Task.nondeterminism
+    Applicative[Task]
+  }
 
   def runAsync[R, A](e: Eff[R, A])(implicit m: Member.Aux[Task, R, NoFx]): Task[A] =
     Eff.detachA(e)(monixTaskMonad, monixTaskApplicative, m)


### PR DESCRIPTION
and added a new cats-effect module to integrate the IO effect.

For the adventurous this is published as `4.6.1-20170908220345-65de2ec`.

Review @edmundnoble 