### PR TITLE
Upgrade monix to 3.0.0-RC1, cats effect to 0.10.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,13 +9,13 @@ import sbtrelease._
 import org.scalajs.jsenv.nodejs._
 
 lazy val catsVersion        = "1.0.1"
-lazy val monixVersion       = "3.0.0-M3"
+lazy val monixVersion       = "3.0.0-RC1"
 lazy val scalazVersion      = "7.2.7"
 lazy val specs2Version      = "4.0.2"
 lazy val twitterUtilVersion = "17.11.0"
 lazy val catbirdVersion     = "0.21.0"
 lazy val doobieVersion      = "0.5.0"
-lazy val catsEffectVersion  = "0.9"
+lazy val catsEffectVersion  = "0.10.1"
 lazy val fs2Version         = "0.10.2"
 
 lazy val eff = project.in(file("."))

--- a/cats/src/main/scala/org/atnos/eff/addon/cats/effect/IOEffect.scala
+++ b/cats/src/main/scala/org/atnos/eff/addon/cats/effect/IOEffect.scala
@@ -26,19 +26,19 @@ trait IOEffectCreation extends IOTypes {
     io.send[R]
 
   final def ioRaiseError[R :_io, A](t: Throwable): Eff[R, A] =
-    IO.ioEffect.raiseError(t).send[R]
+    IO.raiseError(t).send[R]
 
   final def ioDelay[R :_io, A](io: =>A): Eff[R, A] =
-    IO.ioEffect.delay(io).send[R]
+    IO(io).send[R]
 
   final def ioFork[R :_io, A](io: =>A)(implicit ec: ExecutionContext): Eff[R, A] =
     ioShift >> ioDelay(io)
 
   final def ioSuspend[R :_io, A](io: =>IO[Eff[R, A]]): Eff[R, A] =
-    IO.ioEffect.suspend(io).send[R].flatten
+    IO.suspend(io).send[R].flatten
 
   final def ioShift[R :_io](implicit ec: ExecutionContext): Eff[R, Unit] =
-    IO.ioEffect.shift(ec).send[R]
+    IO.shift(ec).send[R]
 
 }
 


### PR DESCRIPTION
 There were quite a few deprecated APIs as both Monix and Cats effect are rapidly evolving. Most migrations were exactly as per the deprecation advice.

One choice Im unsure about was [casting `Applicative[Task.Par]` to `Applicative[Task]`](https://github.com/atnos-org/eff/compare/master...benhutchison:monixupdate?expand=1#diff-e2389f0077c98d9bb90fdb1ab4893dc6R72). It seems like a clash of techniques: Eff's Task addon had chosen to explicitly pass the instances, while Monix had chosen to use a newtype wrapper around Task.