### PR TITLE
modifyS 

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/StateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/StateEffectSpec.scala
@@ -21,6 +21,8 @@ class StateEffectSpec extends Specification with ScalaCheck { def is = s2"""
 
  The Eff monad is stack safe with State $stacksafeState
 
+ modifyS is a modify variant that enables better type inference for state modification closures $modifySState
+
 """
 
   def putGetState = {
@@ -131,6 +133,18 @@ class StateEffectSpec extends Specification with ScalaCheck { def is = s2"""
       } yield ()
 
     updatePerson[Fx.fx2[String Either ?, State[Person, ?]]].evalState(Person(Address("here"))).runEither.run ==== Right(())
+  }
+
+
+  def modifySState = {
+
+    def action[R :_stateInt]: Eff[R, String] = for {
+      a <- get
+      _ <- put(a + 1)
+      _ <- modifyS.using(_ + 10)
+    } yield a.toString
+
+    action[SI].execStateZero[Int].run ==== 11
   }
 
   type StateInt[A] = State[Int, A]

--- a/shared/src/main/scala/org/atnos/eff/StateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/StateEffect.scala
@@ -36,6 +36,14 @@ trait StateCreation {
   def modify[R, S](f: S => S)(implicit member: State[S, ?] |= R): Eff[R, Unit] =
     send[State[S, ?], R, Unit](State.modify(f))
 
+  /** `modifyS.using` is a `modify` variant that often enables better type inference for the modify function `f`
+    * (when used in an effect stack with a single state effect).
+    *
+    * It does this by capturing the type params `R` and `S` before receiving the `f: S => S` parameter.  */
+  def modifyS[R, S](implicit member: State[S, ?] |= R) = new {
+    def using(f: S => S): Eff[R, Unit] = modify[R, S](f)
+  }
+
 }
 
 trait StateImplicits {


### PR DESCRIPTION
`modifyS.using` is a State `modify` variant that often enables better type inference for the modify function `f`(when used in an effect stack with a single state effect).

It does this by capturing the type params `R` and `S` before receiving the `f: S => S` parameter.


Discussion: There's potentially a huge number of similar ergonomic improvements to the Eff API. It's debatable whether they should go into Eff core or an extension library. I can go either way. @etorreborre WDYT?

I do find that the amount of type annotation needed to make Eff work is cumbersome. Hence Im investing effort into trying to find idioms that work well with scalas type inference (like this example). Probably more to come..