### PR TITLE
Ior in validate effect

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -44,7 +44,7 @@ trait ValidateCreation {
     send[Validate[E, ?], R, Unit](Correct[E]()) >> Eff.EffMonad[R].pure(a)
 
   /** create a pure warning */
-  def warning[R, E, A](e: E)(implicit m: Validate[E, ?] |= R): Eff[R, Unit] =
+  def warning[R, E](e: E)(implicit m: Validate[E, ?] |= R): Eff[R, Unit] =
     send[Validate[E, ?], R, Unit](Correct[E](Some(e)))
 
   /** create a correct value with warning */

--- a/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
@@ -1,6 +1,6 @@
 package org.atnos.eff.syntax
 
-import cats.data.{NonEmptyList, ValidatedNel}
+import cats.data.{Ior, IorNel, NonEmptyList, ValidatedNel}
 import org.atnos.eff._
 import cats.Semigroup
 
@@ -18,6 +18,12 @@ trait validate {
 
     def runValidatedNel[E](implicit m: Member[Validate[E, ?], R]): Eff[m.Out, ValidatedNel[E, A]] =
       ValidateInterpretation.runValidatedNel(e)(m.aux)
+
+    def runIorMap[E, L : Semigroup](map: E => L)(implicit m: Member[Validate[E, ?], R]): Eff[m.Out, L Ior A] =
+      ValidateInterpretation.runIorMap(e)(map)(Semigroup[L], m.aux)
+
+    def runIorNel[E](implicit m: Member[Validate[E, ?], R]): Eff[m.Out, E IorNel A] =
+      ValidateInterpretation.runIorNel(e)(m.aux)
 
     def catchWrong[E](handle: E => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
       ValidateInterpretation.catchWrong(e)(handle)


### PR DESCRIPTION
`Validate` effect was changed to be able to be interpreted as `cats.Ior`.

Special warning construction functions were added for constructing errors that are not fatal (equivalent to `Ior`'s `Both`). Treatment of such warnings in existing `Either`/`Validated` interpreters has been made to be the same as what `Ior.toEither` does.