### PR TITLE
Simpler implementation of applicative effect for errors catching

### DIFF
--- a/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
@@ -94,7 +94,7 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
         a <- EffMonad[S].pure(3)
       } yield a
 
-    validate.catchWrong((s: String) => pure(4)).runNel.run ==== Right(4)
+    validate.catchFirstWrong((s: String) => pure(4)).runNel.run ==== Right(4)
   }
 
   def catchWrongValues2 = {
@@ -105,8 +105,8 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
     val handle: E => Check[Unit] = { case e => tell[Comput, E](e).as(()) }
 
     val comp1: Check[Int] = for {
-      _ <- wrong[Comput, E]("1").catchWrong(handle)
-      _ <- wrong[Comput, E]("2").catchWrong(handle)
+      _ <- wrong[Comput, E]("1").catchFirstWrong(handle)
+      _ <- wrong[Comput, E]("2").catchFirstWrong(handle)
     } yield 0
 
     val comp2: Check[Int] = comp1

--- a/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
@@ -11,10 +11,11 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
  run the validate effect                     $validateOk
  run the validate effect with nothing        $validateKo
 
- run the validate effect (IorNel variant)    $validateIorOk
- run the validate effect with warnings       $validateWarn
- run the validate effect with warn & err     $validateWarnAndErr
- run the validate effect with errs & warn    $validateWarnAndErr
+ `Ior`ish or warnings-oriented validation
+   run resulting IorNel                      $validateIorOk
+   run with warnings                         $validateWarn
+   run with warnings and errors              $validateWarnAndErr
+   run with errors and warning               $validateWarnAndErr
 
  recover from wrong values                   $catchWrongValues1
  recover from wrong values and tell errors   $catchWrongValues2

--- a/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
@@ -21,7 +21,7 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
  recover, check that the first is catched    $catchFirstWrongValue
  recover, check that all are catched, simple $catchAllWrongValuesLinear
  recover, check that the last is catched     $catchLastWrongValue
- recover, the whole list is catched          $catchAllWrongValuesApplicative
+ recover, the whole list is catched          $catctListOfWrongValues
 
  run is stack safe with Validate  $stacksafeRun
 
@@ -142,7 +142,7 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
     validate.catchAllWrongs((ss: NonEmptyList[String]) => pure(ss.mkString_("", ", ", ""))).runNel.run ==== Right("error1, error2")
   }
 
-  def catchAllWrongValuesApplicative = {
+  def catctListOfWrongValues = {
     type C = Fx.fx2[ValidateString, List]
     val validate: Eff[C, String] =
       for {

--- a/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
@@ -29,7 +29,7 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
    all are catched                           ${ForCatchingEffApplicative.catchAllWrongValues}
    the last is catched                       ${ForCatchingEffApplicative.catchLastWrongValue}
 
- recover, the whole list is catched          $catctListOfWrongValues
+ recover, the whole list is catched          $catchListOfWrongValues
 
  run is stack safe with Validate  $stacksafeRun
 
@@ -174,7 +174,7 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
     }
   }
 
-  def catctListOfWrongValues = {
+  def catchListOfWrongValues = {
     type C = Fx.fx2[ValidateString, List]
     val validate: Eff[C, String] =
       for {

--- a/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
@@ -130,6 +130,8 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
     validate.catchFirstWrong((s: String) => pure(s)).runNel.run ==== Right("error1")
   }
 
+  private def smashNelOfStrings[R](ss: NonEmptyList[String]): Eff[R, String] = pure(ss.mkString_("", ", ", ""))
+
   def catchAllWrongValuesLinear = {
     val validate: Eff[S, String] =
       for {
@@ -139,7 +141,7 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
         _ <- ValidateEffect.wrong[S, String]("error2")
       } yield a.toString
 
-    validate.catchAllWrongs((ss: NonEmptyList[String]) => pure(ss.mkString_("", ", ", ""))).runNel.run ==== Right("error1, error2")
+    validate.catchAllWrongs(smashNelOfStrings).runNel.run ==== Right("error1, error2")
   }
 
   def catctListOfWrongValues = {

--- a/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
+++ b/jvm/src/test/scala/org/atnos/eff/ValidateEffectSpec.scala
@@ -153,9 +153,9 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
   }
 
   object ForCatchingEffApplicative {
-    val v1: Eff[S, Int] = ValidateEffect.validateValue(condition = true, 5, "error1")
-    val v2: Eff[S, String] = ValidateEffect.validateValue(condition = false, "str", "error2")
-    val v3: Eff[S, Int] = ValidateEffect.validateValue(condition = false, 6, "error3")
+    val v1: Eff[S, Int] = ValidateEffect.validateValue(condition = true, 5, "no error")
+    val v2: Eff[S, String] = ValidateEffect.validateValue(condition = false, "str", "error1")
+    val v3: Eff[S, Int] = ValidateEffect.validateValue(condition = false, 6, "error2")
 
     final case class Prod(x: Int, s: String, y: Int)
 
@@ -163,15 +163,15 @@ class ValidateEffectSpec extends Specification with ScalaCheck { def is = s2"""
     val v: Eff[S, String] = prod.map(_.toString)
 
     def catchFirstWrongValue = {
-      v.catchFirstWrong((s: String) => pure(s)).runNel.run ==== Right("error2")
+      v.catchFirstWrong((s: String) => pure(s)).runNel.run ==== Right("error1")
     }
 
     def catchAllWrongValues = {
-      v.catchAllWrongs(smashNelOfStrings).runNel.run ==== Right("error2, error3")
+      v.catchAllWrongs(smashNelOfStrings).runNel.run ==== Right("error1, error2")
     }
 
     def catchLastWrongValue = {
-      v.catchLastWrong((s: String) => pure(s)).runNel.run ==== Right("error3")
+      v.catchLastWrong((s: String) => pure(s)).runNel.run ==== Right("error2")
     }
   }
 

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -121,7 +121,9 @@ trait ValidateInterpretation extends ValidateCreation {
 
       def onApplicativeEffect[X, T[_] : Traverse](xs: T[Validate[E, X]], continuation: Continuation[U, T[X], L SomeOr A]): Eff[U, L SomeOr A] = {
         l = xs.foldLeft(l)(combineLV)
-        Eff.impure(xs.map(_ => ().asInstanceOf[X]), continuation)
+
+        val tx: T[X] = xs.map { case Correct() | Warning(_) | Wrong(_) => () }
+        Eff.impure(tx, continuation)
       }
     })
 

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -165,6 +165,10 @@ trait ValidateInterpretation extends ValidateCreation {
     catchWrongs[R, E, A, Id](effect)(handle)
   }
 
+  /** catch and handle all wrong values */
+  def catchAllWrongs[R, E, A](effect: Eff[R, A])(handle: NonEmptyList[E] => Eff[R, A])(implicit member: Validate[E, ?] <= R): Eff[R, A] =
+    catchWrongs(effect)(handle)
+
   /** catch and handle possible wrong values */
   @deprecated("Use catchFirstWrong or more general catchWrongs instead", "5.4.0")
   def catchWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: (Validate[E, ?]) <= R): Eff[R, A] =

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -154,6 +154,12 @@ trait ValidateInterpretation extends ValidateCreation {
       }
     })
 
+  /** catch and handle the first wrong value */
+  def catchFirstWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: Validate[E, ?] <= R): Eff[R, A] = {
+    implicit val first: Semigroup[E] = (a, _) => a
+    catchWrongs[R, E, A, Id](effect)(handle)
+  }
+
   /** catch and handle possible wrong values */
   def catchWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: (Validate[E, ?]) <= R): Eff[R, A] =
     intercept(effect)(new Interpreter[Validate[E, ?], R, A, A] {

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -175,7 +175,7 @@ trait ValidateInterpretation extends ValidateCreation {
     catchWrongs(effect)(handle)
 
   /** catch and handle possible wrong values */
-  @deprecated("Use catchFirstWrong or more general catchWrongs instead", "5.4.0")
+  @deprecated("Use catchFirstWrong or more general catchWrongs instead", "5.4.2")
   def catchWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: (Validate[E, ?]) <= R): Eff[R, A] =
     catchFirstWrong(effect)(handle)
 }

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -165,6 +165,12 @@ trait ValidateInterpretation extends ValidateCreation {
     catchWrongs[R, E, A, Id](effect)(handle)
   }
 
+  /** catch and handle the first wrong value */
+  def catchLastWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: Validate[E, ?] <= R): Eff[R, A] = {
+    implicit val last: Semigroup[E] = (_, b) => b
+    catchWrongs[R, E, A, Id](effect)(handle)
+  }
+
   /** catch and handle all wrong values */
   def catchAllWrongs[R, E, A](effect: Eff[R, A])(handle: NonEmptyList[E] => Eff[R, A])(implicit member: Validate[E, ?] <= R): Eff[R, A] =
     catchWrongs(effect)(handle)

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -166,7 +166,7 @@ trait ValidateInterpretation extends ValidateCreation {
   }
 
   /** catch and handle possible wrong values */
-  @deprecated("Use catchFirstWrong instead", "5.4.0")
+  @deprecated("Use catchFirstWrong or more general catchWrongs instead", "5.4.0")
   def catchWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: (Validate[E, ?]) <= R): Eff[R, A] =
     catchFirstWrong(effect)(handle)
 }

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -165,13 +165,13 @@ trait ValidateInterpretation extends ValidateCreation {
 
   /** catch and handle the first wrong value */
   def catchFirstWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: Validate[E, ?] <= R): Eff[R, A] = {
-    implicit val first: Semigroup[E] = (a, _) => a
+    implicit val first: Semigroup[E] = Semigroup.instance{ (a, _) => a }
     catchWrongs[R, E, A, Id](effect)(handle)
   }
 
   /** catch and handle the first wrong value */
   def catchLastWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: Validate[E, ?] <= R): Eff[R, A] = {
-    implicit val last: Semigroup[E] = (_, b) => b
+    implicit val last: Semigroup[E] = Semigroup.instance{ (_, b) => b }
     catchWrongs[R, E, A, Id](effect)(handle)
   }
 

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -154,7 +154,11 @@ trait ValidateInterpretation extends ValidateCreation {
 
         traversed match {
           case Valid(tx)  => Eff.impure(tx, continuation)
-          case Invalid(e) => handle(errs.fold(e)(_ |+| e))
+          case Invalid(e) => {
+            errs = errs |+| Some(e)
+            // Coercion is yet safe since only Validate[?, Unit] exist
+            Eff.impure(xs.map(_ => ().asInstanceOf[X]), continuation)
+          }
         }
       }
     })

--- a/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
+++ b/shared/src/main/scala/org/atnos/eff/ValidateEffect.scala
@@ -166,7 +166,7 @@ trait ValidateInterpretation extends ValidateCreation {
     catchWrongs[R, E, A, Id](effect)(handle)
   }
 
-  /** catch and handle the first wrong value */
+  /** catch and handle the last wrong value */
   def catchLastWrong[R, E, A](effect: Eff[R, A])(handle: E => Eff[R, A])(implicit member: Validate[E, ?] <= R): Eff[R, A] = {
     implicit val last: Semigroup[E] = Semigroup.instance{ (_, b) => b }
     catchWrongs[R, E, A, Id](effect)(handle)

--- a/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
@@ -35,6 +35,9 @@ trait validate {
     def catchFirstWrong[E](handle: E => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
       ValidateInterpretation.catchFirstWrong(e)(handle)
 
+    def catchLastWrong[E](handle: E => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
+      ValidateInterpretation.catchLastWrong(e)(handle)
+
     def catchAllWrongs[E](handle: NonEmptyList[E] => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
       ValidateInterpretation.catchAllWrongs(e)(handle)
   }

--- a/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
@@ -34,6 +34,9 @@ trait validate {
 
     def catchFirstWrong[E](handle: E => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
       ValidateInterpretation.catchFirstWrong(e)(handle)
+
+    def catchAllWrongs[E](handle: NonEmptyList[E] => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
+      ValidateInterpretation.catchAllWrongs(e)(handle)
   }
 
 }

--- a/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
@@ -2,7 +2,7 @@ package org.atnos.eff.syntax
 
 import cats.data.{Ior, IorNel, NonEmptyList, ValidatedNel}
 import org.atnos.eff._
-import cats.Semigroup
+import cats.{Applicative, Semigroup}
 
 object validate extends validate
 
@@ -25,9 +25,15 @@ trait validate {
     def runIorNel[E](implicit m: Member[Validate[E, ?], R]): Eff[m.Out, E IorNel A] =
       ValidateInterpretation.runIorNel(e)(m.aux)
 
+    @deprecated("Use catchFirstWrong or more general catchWrongs instead", "5.4.0")
     def catchWrong[E](handle: E => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
       ValidateInterpretation.catchWrong(e)(handle)
 
+    def catchWrongs[E, S[_]: Applicative](handle: S[E] => Eff[R, A])(implicit m: Member[Validate[E, ?], R], semi: Semigroup[S[E]]): Eff[R, A] =
+      ValidateInterpretation.catchWrongs(e)(handle)
+
+    def catchFirstWrong[E](handle: E => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
+      ValidateInterpretation.catchFirstWrong(e)(handle)
   }
 
 }

--- a/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/validate.scala
@@ -25,7 +25,7 @@ trait validate {
     def runIorNel[E](implicit m: Member[Validate[E, ?], R]): Eff[m.Out, E IorNel A] =
       ValidateInterpretation.runIorNel(e)(m.aux)
 
-    @deprecated("Use catchFirstWrong or more general catchWrongs instead", "5.4.0")
+    @deprecated("Use catchFirstWrong or more general catchWrongs instead", "5.4.2")
     def catchWrong[E](handle: E => Eff[R, A])(implicit m: Member[Validate[E, ?], R]): Eff[R, A] =
       ValidateInterpretation.catchWrong(e)(handle)
 


### PR DESCRIPTION
I suggest a simpler implementation of applicative effect interpreter of the `ValidateEffect` 's `catchWrong` interpreter.

The idea of simplification came by observing the existing implementation and realizing that `catchWrong` actually catches only the first one. Thus, internal state on applicative can be represented as a simple `Either` actually.

---

What I suggest also (but afraid to do due to source incompatibility) is **to rename** the current `catchWrong` to `catchFirstWrong` because it loses all errors except the first one like in cases where

- we have several consequent `wrong` calls or
- when we have some traversable effect like `List` interpreted before the `Validate` effect, i.e. like `runList.catchWrong(whatever).runNel.run`).

Yet, it is the simplest known catcher thus, maybe, still useful.

---

Universal catcher should have a choice to give the right value, to ignore this error in order to let the catcher to work with other errors or to combine the result of catching of an error with other errors catcher's results. While the last seems to be doable (still having problems or whether being able to recatch previously thrown error inside the catcher or ont), the second looks yet a little bit too error-prone to implement.

Still, I want to discuss whether or not existing `catchWrong` can be renamed or not.