### PR TITLE
Adopt the Scala Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+[eff](https://github.com/atnos-org/eff/) is a [Typelevel](http://typelevel.org) project. This means we embrace pure, typeful, functional programming,
+and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](https://www.scala-lang.org/conduct/).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ scalaOrganization in ThisBuild := "org.typelevel"
 # Contributing
 
 [eff](https://github.com/atnos-org/eff/) is a [Typelevel](http://typelevel.org) project. This means we embrace pure, typeful, functional programming,
-and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Typelevel Code of Conduct](http://typelevel.org/conduct.html).
+and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](https://www.scala-lang.org/conduct/).
 
 Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about the code. Pull requests are also gladly accepted.

--- a/src/test/scala/org/atnos/site/index.scala
+++ b/src/test/scala/org/atnos/site/index.scala
@@ -22,7 +22,7 @@ You can learn more in the following sections, it is recommended to read them in 
 ### Contributing
 
 `eff` is a [Typelevel](http://typelevel.org) project. This means we embrace pure, typeful, functional programming,
-and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Typelevel Code of Conduct](http://typelevel.org/conduct.html).
+and provide a safe and friendly environment for teaching, learning, and contributing as described in the [Scala Code of Conduct](https://www.scala-lang.org/conduct/).
 
 Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about the code. Pull requests are also gladly accepted.
 


### PR DESCRIPTION
Typelevel is about to announce that it is moving to the Scala Code of Conduct for all participating projects. The Scala Code of Conduct was by developed by the Scala Center with input from Typelevel and improves on the Typelevel code of conduct in a number of ways and can be thought of as the "Typelevel code of conduct v. 2.0". We want people participating in projects and activities right across the Scala ecosystem to be able to expect a uniform standard of good behavior, and coordinating on a shared code of conduct is an important step in that direction.