### PR TITLE
Add up to 20 fx types

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/Fx.scala
+++ b/shared/src/main/scala/org/atnos/eff/Fx.scala
@@ -31,6 +31,29 @@ object Fx {
   type fx11[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_]] = FxAppend[Fx2[T1, T2], FxAppend[Fx3[T3, T4, T5], FxAppend[Fx3[T6, T7, T8], Fx3[T9, T10, T11]]]]
   type fx12[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_]] = FxAppend[Fx3[T1, T2, T3], FxAppend[Fx3[T4, T5, T6], FxAppend[Fx3[T7, T8, T9], Fx3[T10, T11, T12]]]]
 
+  type fx13[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_]] =
+    FxAppend[Fx1[T1], FxAppend[Fx3[T2, T3, T4], FxAppend[Fx3[T5, T6, T7], FxAppend[Fx3[T8, T9, T10], Fx3[T11, T12, T13]]]]]
+
+  type fx14[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_], T14[_]] =
+    FxAppend[Fx2[T1, T2], FxAppend[Fx3[T3, T4, T5], FxAppend[Fx3[T6, T7, T8], FxAppend[Fx3[T9, T10, T11], Fx3[T12, T13, T14]]]]]
+
+  type fx15[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_], T14[_], T15[_]] =
+    FxAppend[Fx3[T1, T2, T3], FxAppend[Fx3[T4, T5, T6], FxAppend[Fx3[T7, T8, T9], FxAppend[Fx3[T10, T11, T12], Fx3[T13, T14, T15]]]]]
+
+  type fx16[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_], T14[_], T15[_], T16[_]] =
+    FxAppend[Fx1[T1], FxAppend[Fx3[T2, T3, T4], FxAppend[Fx3[T5, T6, T7], FxAppend[Fx3[T8, T9, T10], FxAppend[Fx3[T11, T12, T13], Fx3[T14, T15, T16]]]]]]
+
+  type fx17[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_], T14[_], T15[_], T16[_], T17[_]] =
+    FxAppend[Fx2[T1, T2], FxAppend[Fx3[T3, T4, T5], FxAppend[Fx3[T6, T7, T8], FxAppend[Fx3[T9, T10, T11], FxAppend[Fx3[T12, T13, T14], Fx3[T15, T16, T17]]]]]]
+
+  type fx18[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_], T14[_], T15[_], T16[_], T17[_], T18[_]] =
+    FxAppend[Fx3[T1, T2, T3], FxAppend[Fx3[T4, T5, T6], FxAppend[Fx3[T7, T8, T9], FxAppend[Fx3[T10, T11, T12], FxAppend[Fx3[T13, T14, T15], Fx3[T16, T17, T18]]]]]]
+
+  type fx19[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_], T14[_], T15[_], T16[_], T17[_], T18[_], T19[_]] =
+    FxAppend[Fx1[T1], FxAppend[Fx3[T2, T3, T4], FxAppend[Fx3[T5, T6, T7], FxAppend[Fx3[T8, T9, T10], FxAppend[Fx3[T11, T12, T13], FxAppend[Fx3[T14, T15, T16], Fx3[T17, T18, T19]]]]]]]
+
+  type fx20[T1[_], T2[_], T3[_], T4[_], T5[_], T6[_], T7[_], T8[_], T9[_], T10[_], T11[_], T12[_], T13[_], T14[_], T15[_], T16[_], T17[_], T18[_], T19[_], T20[_]] =
+    FxAppend[Fx2[T1, T2], FxAppend[Fx3[T3, T4, T5], FxAppend[Fx3[T6, T7, T8], FxAppend[Fx3[T9, T10, T11], FxAppend[Fx3[T12, T13, T14], FxAppend[Fx3[T15, T16, T17], Fx3[T18, T19, T20]]]]]]]
 }
 
 /**


### PR DESCRIPTION
Hello,

This PR adds more `fx` `type`s, up to 20. 

Reason being that past 12 effects, a current solution is to use `append`/`prepend`. I think this will make that look cleaner.

This clearly isn't the most elegant way, so I'm happy to close this if there's more favorable way of doing it.

I don't know why the limit was set to 12 before. If that was an actual limitation in the past then maybe this won't work for all consumers, but I tested and compiled this locally and seemed to work fine.

Thank you!