### PR TITLE
Fix `addLast`

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/Last.scala
+++ b/shared/src/main/scala/org/atnos/eff/Last.scala
@@ -22,7 +22,7 @@ case class Last[R](value: Option[Eval[Eff[R, Unit]]]) {
       case (None, None)       => this
       case (Some(r), None)    => this
       case (None, Some(l))    => last
-      case (Some(r), Some(l)) => Last(Option(r *> l))
+      case (Some(r), Some(l)) => Last(Option(r.map2(l)((a, b) => b <* a)))
     }
 
   def *>(last: Last[R]): Last[R] =
@@ -30,7 +30,7 @@ case class Last[R](value: Option[Eval[Eff[R, Unit]]]) {
       case (None, None)       => this
       case (Some(r), None)    => this
       case (None, Some(l))    => last
-      case (Some(r), Some(l)) => Last(Option(r *> l))
+      case (Some(r), Some(l)) => Last(Option(r.map2(l)(_ *> _)))
     }
 }
 


### PR DESCRIPTION
- The former implementation is `Last(Option(r *> l))`, which only composes `Eval` level but `r` and `l` have `Eff` inside the `Eval`
    - Even if the side-effect written in `Eff` and call `addLast` for several times, all last actions except for the last added one will be gone! 😇 
- We have to compose `Eff`s which are inside of `r` and `l`, using `map2` or `*>`
- I use the `*>`(`productR`) like operation to compose `Eval`s, but use `<*`(`productL`) to compose `Eff`s
    - https://github.com/atnos-org/eff/compare/master...y-yu:fix-addLast?expand=1#diff-e33d34e10616bc3feaaf9f68c4040fb2R25
    - I don't know how it works but it passed the test