### PR TITLE
Replace applicative methods for composing last actions to `flatMap`

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/Choose.scala
+++ b/shared/src/main/scala/org/atnos/eff/Choose.scala
@@ -77,7 +77,7 @@ trait ChooseInterpretation {
         case e :: rest =>
           e match {
             case Pure(a, last) =>
-              go(rest, (EffMonad[U].pure(alternativeF.pure(a)), result).mapN(alternativeF.combineK), resultLast.map(_ <* lastRun(last)))
+              go(rest, (EffMonad[U].pure(alternativeF.pure(a)), result).mapN(alternativeF.combineK), resultLast.map(_ << lastRun(last)))
 
             case Impure(NoEffect(a), c, last) =>
               runChoose(c(a).addLast(last))

--- a/shared/src/main/scala/org/atnos/eff/Continuation.scala
+++ b/shared/src/main/scala/org/atnos/eff/Continuation.scala
@@ -57,13 +57,13 @@ case class Continuation[R, A, B](functions: Vector[Any => Eff[R, Any]], onNone: 
           } else {
             fv match {
               case Pure(a1, l1) =>
-                go(rest, a1, last *> l1)
+                go(rest, a1, last >> l1)
 
               case Impure(u, q, l) =>
-                Impure[R, u.X, B](u, q.copy(q.functions ++ rest, onNone = q.onNone *> onNone), last *> l)
+                Impure[R, u.X, B](u, q.copy(q.functions ++ rest, onNone = q.onNone >> onNone), last >> l)
 
               case ImpureAp(unions, q, l) =>
-                ImpureAp[R, unions.X, B](unions, q.copy(q.functions ++ rest, onNone = q.onNone *> onNone), last *> l)
+                ImpureAp[R, unions.X, B](unions, q.copy(q.functions ++ rest, onNone = q.onNone >> onNone), last >> l)
             }
           }
       }

--- a/shared/src/main/scala/org/atnos/eff/Last.scala
+++ b/shared/src/main/scala/org/atnos/eff/Last.scala
@@ -17,20 +17,20 @@ case class Last[R](value: Option[Eval[Eff[R, Unit]]]) {
   def interpretEff[U](n: Last[R] => Eff[U, Unit]): Last[U] =
     Last.eff(n(this))
 
-  def <*(last: Last[R]): Last[R] =
+  def <<(last: Last[R]): Last[R] =
     (value, last.value) match {
       case (None, None)       => this
       case (Some(r), None)    => this
       case (None, Some(l))    => last
-      case (Some(r), Some(l)) => Last(Option(r.map2(l)((a, b) => b <* a)))
+      case (Some(r), Some(l)) => Last(Option(r.map2(l)(_ >> _)))
     }
 
-  def *>(last: Last[R]): Last[R] =
+  def >>(last: Last[R]): Last[R] =
     (value, last.value) match {
       case (None, None)       => this
       case (Some(r), None)    => this
       case (None, Some(l))    => last
-      case (Some(r), Some(l)) => Last(Option(r.map2(l)(_ *> _)))
+      case (Some(r), Some(l)) => Last(Option(r.map2(l)(_ >> _)))
     }
 }
 


### PR DESCRIPTION
- Since #290, any last action is not gone if we call `addLast` several times
- It uses applicative methods (`map2`, `*>` and `<*`) to compose last action `Eff`s, the order of execution for last actions is up the interpreter
- atnos-eff's `Interperter` interface allows us to implement the special applicative case as `onApplicativeEffect`
    - so we can improve our interpreter's efficiency
- However, I don't agree that last actions (which added by `addLast`) should be executed applicatively, I want to know the order of the execution from code
- For example, in the current implementation `addLast` to the `Eff[Task, A]` is not the same of that of `Eff[Eval, A]`
- Because I change applicative methods to `flatMap`, and then `Eff[Task, A]` and `Eff[Eval, A]` are the same
    - I think it's simpler than before 🤔 
- Discussions are very welcome!
