### PR TITLE
[scala3 compat] Enable implicit-conversion explicitly

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/syntax/batch.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/batch.scala
@@ -1,5 +1,7 @@
 package org.atnos.eff.syntax
 
+import scala.language.implicitConversions
+
 import org.atnos.eff._
 
 object batch extends batch

--- a/shared/src/main/scala/org/atnos/eff/syntax/choose.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/choose.scala
@@ -1,5 +1,7 @@
 package org.atnos.eff.syntax
 
+import scala.language.implicitConversions
+
 import cats.Alternative
 import org.atnos.eff._
 
@@ -7,7 +9,7 @@ object choose extends choose
 
 trait choose {
   implicit final def toChooseEffectOps[R, A](e: Eff[R, A]): ChooseEffectOps[R, A] = new ChooseEffectOps(e)
-}
+}˚
 
 final class ChooseEffectOps[R, A](private val e: Eff[R, A]) extends AnyVal {
 

--- a/shared/src/main/scala/org/atnos/eff/syntax/either.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/either.scala
@@ -1,5 +1,7 @@
 package org.atnos.eff.syntax
 
+import scala.language.implicitConversions
+
 import cats.Semigroup
 import org.atnos.eff._
 

--- a/shared/src/main/scala/org/atnos/eff/syntax/error.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/error.scala
@@ -1,6 +1,8 @@
 package org.atnos.eff
 package syntax
 
+import scala.language.implicitConversions
+
 import ErrorEffect._
 import scala.reflect.ClassTag
 

--- a/shared/src/main/scala/org/atnos/eff/syntax/eval.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/eval.scala
@@ -1,5 +1,7 @@
 package org.atnos.eff.syntax
 
+import scala.language.implicitConversions
+
 import cats._
 import org.atnos.eff._
 

--- a/shared/src/main/scala/org/atnos/eff/syntax/future.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/future.scala
@@ -1,5 +1,7 @@
 package org.atnos.eff.syntax
 
+import scala.language.implicitConversions
+
 import org.atnos.eff._
 import org.atnos.eff.concurrent.Scheduler
 

--- a/shared/src/main/scala/org/atnos/eff/syntax/memo.scala
+++ b/shared/src/main/scala/org/atnos/eff/syntax/memo.scala
@@ -1,5 +1,7 @@
 package org.atnos.eff.syntax
 
+import scala.language.implicitConversions
+
 import cats._
 import org.atnos.eff._
 


### PR DESCRIPTION
This will resolve warnings on Scala 3

 ```
[warn] -- Feature Warning: /Users/vagrant/IdeaProjects/eff/shared/src/main/scala/org/atnos/eff/syntax/error.scala:11:21 
[warn] 11 |  implicit final def toErrorOrOkOps[A](c: Error Either A): ErrorOrOkOps[A] = new ErrorOrOkOps(c)
[warn]    |                     ^
[warn]    |Definition of implicit conversion method toErrorOrOkOps should be enabled
[warn]    |by adding the import clause 'import scala.language.implicitConversions'
[warn]    |or by setting the compiler option -language:implicitConversions.
```