### PR TITLE
Fix maybe a typo? AuthErroEither in the document

### DIFF
--- a/org.atnos.site.TransformStack.html
+++ b/org.atnos.site.TransformStack.html
@@ -409,8 +409,8 @@ sealed trait Authenticated[A]
 case class Authenticate(token: String) extends Authenticated[AccessRights]
 type _authenticate[U] = Authenticated |= U
 
-type AuthErroEither[A] = AuthError Either A
-type _error[U] = AuthErroEither |= U
+type AuthErrorEither[A] = AuthError Either A
+type _error[U] = AuthErrorEither |= U
 
 /**
  * The order of implicit parameters is really important for type inference!


### PR DESCRIPTION
Hello. Thanks for the awesome library.
I found a typo(?) in the [official documentation](https://atnos-org.github.io/eff/org.atnos.site.TransformStack.html#translate-an-effect-into-multiple-others)
Please point out if there are any mistakes 🙇 
Thank you.