### PR TITLE
Change `MemberInOut` instance priority as same as `MemberIn`

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/Member.scala
+++ b/shared/src/main/scala/org/atnos/eff/Member.scala
@@ -143,8 +143,8 @@ trait MemberInOutLower2 extends MemberInOutLower3 {
   implicit def MemberInOut3L[L[_], M[_], R[_]]: MemberInOut[L, Fx3[L, M, R]] =
     TaggedMemberInOut(1)
 
-  implicit def MemberInOutAppendL[T[_], L, R](implicit append: MemberInOut[T, L]): MemberInOut[T, FxAppend[L, R]] =
-    AppendMemberInOut(isRight = false, append)
+  implicit def MemberInOutAppendAnyL[T[_], R]: MemberInOut[T, FxAppend[Fx1[T], R]] =
+    AppendMemberInOut(isRight = false, TaggedMemberInOut(1))
 }
 
 trait MemberInOutLower3 extends MemberInOutLower4 {
@@ -164,8 +164,8 @@ trait MemberInOutLower4 extends MemberInOutLower5 {
 }
 
 trait MemberInOutLower5 {
-  implicit def MemberInOutAppendAnyL[T[_], R]: MemberInOut[T, FxAppend[Fx1[T], R]] =
-    AppendMemberInOut(isRight = false, TaggedMemberInOut(1))
+  implicit def MemberInOutAppendL[T[_], L, R](implicit append: MemberInOut[T, L]): MemberInOut[T, FxAppend[L, R]] =
+    AppendMemberInOut(isRight = false, append)
 
   implicit def MemberInOutAppendAnyR[T[_], L, R](implicit m: MemberInOut[T, R]): MemberInOut[T, FxAppend[L, R]] =
     AppendMemberInOut(isRight = true, m)

--- a/shared/src/test/scala/org/atnos/eff/MemberImplicitsSpec.scala
+++ b/shared/src/test/scala/org/atnos/eff/MemberImplicitsSpec.scala
@@ -309,4 +309,13 @@ import org.atnos.eff.syntax.all._
   def withOptionEffect2[S: _Option]: Eff[S, Unit] =
     withOptionEffect[Fx.prepend[Reader[String, *], S]].runReader("hello")
 
+  type _OptionInOut[R] = Option /= R
+  type Fx1AppendFx6 = Fx.append[
+    Fx.fx1[Option],
+    Fx.fx6[List, Writer[String, *], Validate[String, *], Reader[String, *], State[Int, *], Either[Throwable, *]]
+  ]
+
+  def withOptionInOutEffect[S: _OptionInOut]: Eff[S, Unit] = ???
+  def fx1AppendFx6Action =
+    withOptionInOutEffect[Fx1AppendFx6].runOption
 }


### PR DESCRIPTION
- `MemberIn`'s instance priority order is (1) `MemberInAppendAnyL` then (2) `MemberInAppendL`
    - https://github.com/atnos-org/eff/blob/b4acc2017d374cda12f1ba56711d9b59fd3d6714/shared/src/main/scala/org/atnos/eff/Member.scala#L45-L46
    - https://github.com/atnos-org/eff/blob/b4acc2017d374cda12f1ba56711d9b59fd3d6714/shared/src/main/scala/org/atnos/eff/Member.scala#L66-L67
- `MemberIn`'s instance priority had been changed by #172 
- However `MemberInOut` instance priority is not the same as `MemberIn` ones 😇 
- We found the example in which Scala reports compile errors due to the order:
    ```
    > coreJVM/testOnly org.atnos.eff.MemberImplicitsSpec
    [info] compiling 1 Scala source to /Users/yyu/Desktop/eff/jvm/target/scala-2.13/test-classes ...
    [error] /Users/yyu/Desktop/eff/shared/src/test/scala/org/atnos/eff/MemberImplicitsSpec.scala:323:27: ambiguous implicit values:
    [error]  both method MemberInOutAppendAnyL in trait MemberInOutLower5 of type [T[_], R]org.atnos.eff.MemberInOut[T,org.atnos.eff.FxAppend[org.atnos.eff.Fx1[T],R]]
    [error]  and method MemberInOutAppendL in trait MemberInOutLower2 of type [T[_], L, R](implicit append: org.atnos.eff.MemberInOut[T,L]): org.atnos.eff.MemberInOut[T,org.atnos.eff.FxAppend[L,R]]
    [error]  match expected type MemberImplicitsSpec.this._OptionInOut[MemberImplicitsSpec.this.Fx1AppendFx6]
    [error]     withExampleInOutEffect[Fx1AppendFx6].runOption
    ```
- I change the order of the instances for `MemberInOut` as same as `MemberIn`, then the compile error has gone 👍 