### PR TITLE
Change `addLast(l: Last[R])` to public

### DIFF
--- a/shared/src/main/scala/org/atnos/eff/Eff.scala
+++ b/shared/src/main/scala/org/atnos/eff/Eff.scala
@@ -95,7 +95,7 @@ sealed trait Eff[R, A] {
     addLast(Last.eff(l))
 
   /** add one last action to be executed after any computation chained to this Eff value */
-  private[eff] def addLast(l: Last[R]): Eff[R, A]
+  def addLast(l: Last[R]): Eff[R, A]
 
 }
 


### PR DESCRIPTION
### Motivation

- We want to make interpreters which don't use `Interpret.runInterperter`
    - For example,  `StateInterpretation.runState` uses mutable `var` due to using `Interpret.runInterperter`
        - https://github.com/atnos-org/eff/blob/9e5b759d0f6876cca4cc5f1a419f0e1ed2f4450f/shared/src/main/scala/org/atnos/eff/StateEffect.scala#L91-L93
        - The current implementation is good, but we can implement an other `StateInterpretation.runState` without mutable `var`
- But now `addLast(l: Last[R])` method is `private` so we cannot access 😇 
- I remove `private[eff]`, even if I don't understand why this method is `private`.....

### History 

- This `addLast(l: Last[R])` method had became `private` at https://github.com/atnos-org/eff/commit/2fcc3e51c83d5f354346eda17b0230e0a161e1aa
    - In this commit, also `addLast(l: =>Eff[R, Unit])` became based on `flatMap`
- Then in https://github.com/atnos-org/eff/pull/68, `addLast(l: =>Eff[R, Unit])` was reverted
    - However `addLast(l: Last[R])` wasn't reverted 🤔 